### PR TITLE
TUIPanel!

### DIFF
--- a/TwUI.xcodeproj/project.pbxproj
+++ b/TwUI.xcodeproj/project.pbxproj
@@ -9,6 +9,12 @@
 /* Begin PBXBuildFile section */
 		30D399C9156D8ADD006ECDAE /* TUIProgressBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 30D399C7156D8ADD006ECDAE /* TUIProgressBar.m */; };
 		30D39A0D156D8F71006ECDAE /* TUIProgressBar.h in Headers */ = {isa = PBXBuildFile; fileRef = 30D399C6156D8ADD006ECDAE /* TUIProgressBar.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4830B40615B9CEC40085F84E /* TUIPanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4830B40415B9CEC40085F84E /* TUIPanel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4830B40715B9CEC40085F84E /* TUIPanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4830B40415B9CEC40085F84E /* TUIPanel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4830B40815B9CEC40085F84E /* TUIPanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 4830B40415B9CEC40085F84E /* TUIPanel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4830B40915B9CEC40085F84E /* TUIPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4830B40515B9CEC40085F84E /* TUIPanel.m */; };
+		4830B40A15B9CEC40085F84E /* TUIPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4830B40515B9CEC40085F84E /* TUIPanel.m */; };
+		4830B40B15B9CEC40085F84E /* TUIPanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 4830B40515B9CEC40085F84E /* TUIPanel.m */; };
 		48A10E8115B7769A007F9EE3 /* TUILayoutConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7D15B7769A007F9EE3 /* TUILayoutConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48A10E8215B7769A007F9EE3 /* TUILayoutConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E7E15B7769A007F9EE3 /* TUILayoutConstraint.m */; };
 		48A10E8315B7769A007F9EE3 /* TUILayoutManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7F15B7769A007F9EE3 /* TUILayoutManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -272,6 +278,18 @@
 		CBB74CE513BE6E1900C85CB5 /* TUIViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB74C8E13BE6E1900C85CB5 /* TUIViewController.m */; };
 		CBB74CE613BE6E1900C85CB5 /* TUIViewNSViewContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = CBB74C8F13BE6E1900C85CB5 /* TUIViewNSViewContainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CBB74CE713BE6E1900C85CB5 /* TUIViewNSViewContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB74C9013BE6E1900C85CB5 /* TUIViewNSViewContainer.m */; };
+		D039723F15B7D7CB0092CD26 /* TUILayoutConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E7E15B7769A007F9EE3 /* TUILayoutConstraint.m */; };
+		D039724115B7D7CC0092CD26 /* TUILayoutConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E7E15B7769A007F9EE3 /* TUILayoutConstraint.m */; };
+		D039724215B7D7CE0092CD26 /* TUILayoutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E8015B7769A007F9EE3 /* TUILayoutManager.m */; };
+		D039724315B7D7CE0092CD26 /* TUILayoutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E8015B7769A007F9EE3 /* TUILayoutManager.m */; };
+		D039724415B7D7D40092CD26 /* TUIView+Layout.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E8715B778E8007F9EE3 /* TUIView+Layout.m */; };
+		D039724515B7D7D40092CD26 /* TUIView+Layout.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E8715B778E8007F9EE3 /* TUIView+Layout.m */; };
+		D039724615B7D7D60092CD26 /* TUIView+Layout.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E8A15B77A46007F9EE3 /* TUIView+Layout.h */; };
+		D039724715B7D7D70092CD26 /* TUIView+Layout.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E8A15B77A46007F9EE3 /* TUIView+Layout.h */; };
+		D039724815B7D7DB0092CD26 /* TUILayoutManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7F15B7769A007F9EE3 /* TUILayoutManager.h */; };
+		D039724915B7D7DC0092CD26 /* TUILayoutManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7F15B7769A007F9EE3 /* TUILayoutManager.h */; };
+		D039724A15B7D7DE0092CD26 /* TUILayoutConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7D15B7769A007F9EE3 /* TUILayoutConstraint.h */; };
+		D039724B15B7D7DE0092CD26 /* TUILayoutConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7D15B7769A007F9EE3 /* TUILayoutConstraint.h */; };
 		D040610D15B6A77500F753ED /* TUIAnimationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D040610915B6A77500F753ED /* TUIAnimationManager.m */; };
 		D040610E15B6A77500F753ED /* TUIAnimationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D040610915B6A77500F753ED /* TUIAnimationManager.m */; };
 		D040610F15B6A77500F753ED /* TUIAnimationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D040610915B6A77500F753ED /* TUIAnimationManager.m */; };
@@ -329,18 +347,6 @@
 		D0C7657415B6341800E7AC2C /* TUICAAction.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C7657015B6341800E7AC2C /* TUICAAction.m */; };
 		D0C7657515B6341800E7AC2C /* TUICAAction.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C7657015B6341800E7AC2C /* TUICAAction.m */; };
 		D0C7657615B6341800E7AC2C /* TUICAAction.m in Sources */ = {isa = PBXBuildFile; fileRef = D0C7657015B6341800E7AC2C /* TUICAAction.m */; };
-		D039723F15B7D7CB0092CD26 /* TUILayoutConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E7E15B7769A007F9EE3 /* TUILayoutConstraint.m */; };
-		D039724115B7D7CC0092CD26 /* TUILayoutConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E7E15B7769A007F9EE3 /* TUILayoutConstraint.m */; };
-		D039724215B7D7CE0092CD26 /* TUILayoutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E8015B7769A007F9EE3 /* TUILayoutManager.m */; };
-		D039724315B7D7CE0092CD26 /* TUILayoutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E8015B7769A007F9EE3 /* TUILayoutManager.m */; };
-		D039724415B7D7D40092CD26 /* TUIView+Layout.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E8715B778E8007F9EE3 /* TUIView+Layout.m */; };
-		D039724515B7D7D40092CD26 /* TUIView+Layout.m in Sources */ = {isa = PBXBuildFile; fileRef = 48A10E8715B778E8007F9EE3 /* TUIView+Layout.m */; };
-		D039724615B7D7D60092CD26 /* TUIView+Layout.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E8A15B77A46007F9EE3 /* TUIView+Layout.h */; };
-		D039724715B7D7D70092CD26 /* TUIView+Layout.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E8A15B77A46007F9EE3 /* TUIView+Layout.h */; };
-		D039724815B7D7DB0092CD26 /* TUILayoutManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7F15B7769A007F9EE3 /* TUILayoutManager.h */; };
-		D039724915B7D7DC0092CD26 /* TUILayoutManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7F15B7769A007F9EE3 /* TUILayoutManager.h */; };
-		D039724A15B7D7DE0092CD26 /* TUILayoutConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7D15B7769A007F9EE3 /* TUILayoutConstraint.h */; };
-		D039724B15B7D7DE0092CD26 /* TUILayoutConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 48A10E7D15B7769A007F9EE3 /* TUILayoutConstraint.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -356,6 +362,8 @@
 /* Begin PBXFileReference section */
 		30D399C6156D8ADD006ECDAE /* TUIProgressBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TUIProgressBar.h; sourceTree = "<group>"; };
 		30D399C7156D8ADD006ECDAE /* TUIProgressBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TUIProgressBar.m; sourceTree = "<group>"; };
+		4830B40415B9CEC40085F84E /* TUIPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TUIPanel.h; sourceTree = "<group>"; };
+		4830B40515B9CEC40085F84E /* TUIPanel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TUIPanel.m; sourceTree = "<group>"; };
 		48A10E7D15B7769A007F9EE3 /* TUILayoutConstraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TUILayoutConstraint.h; sourceTree = "<group>"; };
 		48A10E7E15B7769A007F9EE3 /* TUILayoutConstraint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TUILayoutConstraint.m; sourceTree = "<group>"; };
 		48A10E7F15B7769A007F9EE3 /* TUILayoutManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TUILayoutManager.h; sourceTree = "<group>"; };
@@ -743,6 +751,8 @@
 				CBB74C6213BE6E1900C85CB5 /* TUINSView.m */,
 				CBB74C6313BE6E1900C85CB5 /* TUINSWindow.h */,
 				CBB74C6413BE6E1900C85CB5 /* TUINSWindow.m */,
+				4830B40415B9CEC40085F84E /* TUIPanel.h */,
+				4830B40515B9CEC40085F84E /* TUIPanel.m */,
 				884E8F5015387E11000F7A8D /* TUIPopover.h */,
 				884E8F5115387E11000F7A8D /* TUIPopover.m */,
 				30D399C6156D8ADD006ECDAE /* TUIProgressBar.h */,
@@ -842,6 +852,7 @@
 				D039724715B7D7D70092CD26 /* TUIView+Layout.h in Headers */,
 				D039724915B7D7DC0092CD26 /* TUILayoutManager.h in Headers */,
 				D039724B15B7D7DE0092CD26 /* TUILayoutConstraint.h in Headers */,
+				4830B40815B9CEC40085F84E /* TUIPanel.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -914,6 +925,7 @@
 				48A10E8115B7769A007F9EE3 /* TUILayoutConstraint.h in Headers */,
 				48A10E8315B7769A007F9EE3 /* TUILayoutManager.h in Headers */,
 				48A10E8B15B77A46007F9EE3 /* TUIView+Layout.h in Headers */,
+				4830B40615B9CEC40085F84E /* TUIPanel.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -942,6 +954,7 @@
 				D039724615B7D7D60092CD26 /* TUIView+Layout.h in Headers */,
 				D039724815B7D7DB0092CD26 /* TUILayoutManager.h in Headers */,
 				D039724A15B7D7DE0092CD26 /* TUILayoutConstraint.h in Headers */,
+				4830B40715B9CEC40085F84E /* TUIPanel.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1157,6 +1170,7 @@
 				D039724115B7D7CC0092CD26 /* TUILayoutConstraint.m in Sources */,
 				D039724315B7D7CE0092CD26 /* TUILayoutManager.m in Sources */,
 				D039724515B7D7D40092CD26 /* TUIView+Layout.m in Sources */,
+				4830B40B15B9CEC40085F84E /* TUIPanel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1236,6 +1250,7 @@
 				48A10E8215B7769A007F9EE3 /* TUILayoutConstraint.m in Sources */,
 				48A10E8415B7769A007F9EE3 /* TUILayoutManager.m in Sources */,
 				48A10E8915B778E8007F9EE3 /* TUIView+Layout.m in Sources */,
+				4830B40915B9CEC40085F84E /* TUIPanel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1321,6 +1336,7 @@
 				D039723F15B7D7CB0092CD26 /* TUILayoutConstraint.m in Sources */,
 				D039724215B7D7CE0092CD26 /* TUILayoutManager.m in Sources */,
 				D039724415B7D7D40092CD26 /* TUIView+Layout.m in Sources */,
+				4830B40A15B9CEC40085F84E /* TUIPanel.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/UIKit/TUIPanel.h
+++ b/lib/UIKit/TUIPanel.h
@@ -1,0 +1,33 @@
+#import <Foundation/Foundation.h>
+#import "TUINSView.h"
+
+// Notes:
+// 
+// - Window Blurring using CGSPrivate.
+// Hmm, doesn't seem to be working for some odd reason. Also need to add a define 
+// macro to disable this if the application is a Mac App Store applicant.
+//
+// - Custom Buttons.
+// NSPanels have close, resize, and zoom buttons, but I've only added the close
+// button. Shouldn't be too difficult, but we need the other two buttons too.
+//
+// - HUD Appearance.
+// This panel looks mostly like the NSPopover, but not anchored with an arrow, and
+// has a small close button. I'll be adding appearance containers soon to allow for
+// the usual Cocoa utility panels and HUD windows as well.
+//
+// - Corner Clipping.
+// I'm not sure how, but there has to be a way to clip subviews to the same corner
+// radius that the theme frame uses. This also causes the resize pointer not to appear.
+
+@interface TUIPanel : NSWindow
+
+@property (nonatomic, assign, getter = isFloatingPanel) BOOL floatingPanel;
+@property (nonatomic, assign) BOOL becomesKeyOnlyIfNeeded;
+@property (nonatomic, assign) BOOL worksWhenModal;
+
+@property (nonatomic, retain) TUIView *rootView;
+
+- (id)initWithContentRect:(CGRect)contentRect;
+
+@end

--- a/lib/UIKit/TUIPanel.m
+++ b/lib/UIKit/TUIPanel.m
@@ -1,0 +1,366 @@
+#import "TUIPanel.h"
+
+CGFloat const TUIPanelCornerRadius = 4.5f;
+CGFloat const TUIPanelTitlebarHeight = 22.0f;
+NSSize const TUIPanelButtonSize = (NSSize){15.0f, 15.0f};
+CGFloat const TUIPanelButtonMargin = 5.0f;
+
+@interface TUIWindowButtonCell : NSButtonCell
+@end
+
+@interface TUIPanelFrame : NSView
+@property (nonatomic, retain) TUINSView *nsView;
+@end
+
+@interface TUIPanel ()
+@property (nonatomic, readonly) TUIPanelFrame *frameView;
+@end
+
+@implementation TUIPanel {
+    TUIView *_popoverRootView;
+    NSView *_popoverContentView;
+    TUIPanelFrame *frameView;
+}
+
+- (id)initWithContentRect:(CGRect)contentRect {
+    if((self = [super initWithContentRect:contentRect
+                                styleMask:NSResizableWindowMask | NSClosableWindowMask
+                                  backing:NSBackingStoreBuffered
+                                    defer:YES])) {
+        [self setOpaque:NO];
+        [self setBackgroundColor:[NSColor clearColor]];
+        [self setHasShadow:YES];
+        
+        [self setReleasedWhenClosed:NO];
+        [self setHidesOnDeactivate:YES];
+        [self setExcludedFromWindowsMenu:YES];
+        
+        [self blurWindow];
+    } return self;
+}
+
+- (void)setTitle:(NSString *)aString {
+    [super setTitle:aString];
+    [[super contentView] setNeedsDisplay:YES];
+}
+
+- (void)setStyleMask:(NSUInteger)styleMask {
+    [self setFloatingPanel:styleMask & NSUtilityWindowMask];
+    [super setStyleMask:styleMask];
+}
+
+- (void)setFloatingPanel:(BOOL)flag {
+    [self setLevel:flag ? NSFloatingWindowLevel : NSNormalWindowLevel];
+}
+
+- (BOOL)isFloatingPanel	{
+    return [self level] == NSFloatingWindowLevel;
+}
+
++ (BOOL)hasMainMenuForStyleMask:(NSUInteger)styleMask {
+    return NO;
+}
+
+- (BOOL)canBecomeKeyWindow {
+    if(self.becomesKeyOnlyIfNeeded)
+		 return [self needsPanelToBecomeKey:self.contentView];
+    else return YES;
+}
+
+- (BOOL)canBecomeMainWindow {
+    return NO;
+}
+
+- (BOOL)acceptsFirstResponder {
+    return YES;
+}
+
+- (TUIView *)rootView {
+    return _popoverRootView;
+}
+
+- (NSView *)contentView {
+    return _popoverContentView;
+}
+
+- (TUIPanelFrame *)frameView {
+    return (TUIPanelFrame *)[super contentView];
+}
+
+- (NSRect)contentRectForFrameRect:(NSRect)windowFrame {
+    windowFrame.origin = NSZeroPoint;
+    windowFrame.size.height -= TUIPanelTitlebarHeight;
+    return windowFrame;
+}
+
++ (NSRect)frameRectForContentRect:(NSRect)windowContentRect
+                        styleMask:(NSUInteger)windowStyle {
+    windowContentRect.size.height += TUIPanelTitlebarHeight;
+    return windowContentRect;
+}
+
+- (NSRect)frameRectForContentRect:(NSRect)windowContent {
+    windowContent.size.height += TUIPanelTitlebarHeight;
+    return windowContent;
+}
+
+- (void)setRootView:(TUIView *)aView {
+    if([_popoverRootView isEqualTo:aView]) return;
+    [self initializeFrame];
+    
+	if(_popoverRootView)
+        [_popoverRootView removeFromSuperview];
+	_popoverRootView = aView;
+    
+	[frameView.nsView setRootView:_popoverRootView];
+}
+
+- (void)setContentView:(NSView *)aView {
+	if([_popoverContentView isEqualTo:aView]) return;
+    [self initializeFrame];
+    
+	if(_popoverContentView)
+        [_popoverContentView removeFromSuperview];
+	_popoverContentView = aView;
+    
+	[_popoverContentView setFrame:[self contentRectForFrameRect:self.frame]];
+	[_popoverContentView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+	[frameView addSubview:_popoverContentView];
+}
+
+- (void)initializeFrame {
+    CGRect bounds = self.frame;
+	bounds.origin = NSZeroPoint;
+    
+	frameView = [super contentView];
+	if(!frameView) {
+		frameView = [[TUIPanelFrame alloc] initWithFrame:bounds];
+        if(self.styleMask & NSClosableWindowMask) {
+            NSSize buttonSize = TUIPanelButtonSize;
+            NSRect buttonRect = NSMakeRect(TUIPanelButtonMargin,
+                                           NSMaxY(frameView.bounds) - (TUIPanelButtonMargin + buttonSize.height),
+                                           buttonSize.width, buttonSize.height);
+            NSButton *closeButton = [[NSButton alloc] initWithFrame:buttonRect];
+            [closeButton setCell:[[TUIWindowButtonCell alloc] init]];
+            [closeButton setButtonType:NSMomentaryChangeButton];
+            [closeButton setTarget:self];
+            [closeButton setAction:@selector(close)];
+            [closeButton setAutoresizingMask:NSViewMaxXMargin | NSViewMinYMargin];
+            [frameView addSubview:closeButton];
+        }
+        
+		[super setContentView:frameView];
+	}
+}
+
+- (void)blurWindow {
+    typedef void* CGSConnectionID;
+    typedef uint32_t CGSWindowFilterRef;
+    
+    extern OSStatus CGSNewConnection(const void **attr, CGSConnectionID *id);
+    extern CGError CGSNewCIFilterByName(CGSConnectionID cid, CFStringRef filterName, CGSWindowFilterRef *outFilter);
+    extern CGError CGSSetCIFilterValuesFromDictionary(CGSConnectionID cid, CGSWindowFilterRef filter, CFDictionaryRef filterValues);
+    extern CGError CGSAddWindowFilter(CGSConnectionID cid, long wid, CGSWindowFilterRef filter, int flags);
+    
+    CGSConnectionID _myConnection;
+    uint32_t __compositingFilter;
+    int __compositingType = 1;
+    
+    CGSNewConnection(NULL , &_myConnection);
+    CGSNewCIFilterByName(_myConnection, (CFStringRef)@"CIGaussianBlur", &__compositingFilter);
+    NSDictionary *optionsDict = [NSDictionary dictionaryWithObject:[NSNumber numberWithFloat:3.0] forKey:@"inputRadius"];
+    CGSSetCIFilterValuesFromDictionary(_myConnection, __compositingFilter, (__bridge CFDictionaryRef)optionsDict);
+    CGSAddWindowFilter(_myConnection, [self windowNumber], __compositingFilter, __compositingType);
+}
+
+/* disabled
+- (void)keyDown:(NSEvent *)event {
+	if([@"\e" isEqualToString:[event charactersIgnoringModifiers]] &&
+       ([self styleMask] & NSClosableWindowMask) == NSClosableWindowMask)
+		 [self close];
+	else [super keyDown:event];
+}//*/
+
+- (void)mouseDown:(NSEvent *)event {
+    NSRect titleBarRect = NSMakeRect(0.f, NSMaxY(frameView.bounds) - TUIPanelTitlebarHeight,
+                                     frameView.bounds.size.width, TUIPanelTitlebarHeight);
+	NSPoint originalMouseLocation = [self convertBaseToScreen:[event locationInWindow]];
+	NSRect originalFrame = [self frame];
+    
+    if(NSPointInRect([event locationInWindow], titleBarRect)) {
+        while(YES) {
+            NSEvent *newEvent = [self nextEventMatchingMask:(NSLeftMouseDraggedMask | NSLeftMouseUpMask)];
+            if([newEvent type] == NSLeftMouseUp)
+                break;
+            
+            NSPoint newMouseLocation = [self convertBaseToScreen:[newEvent locationInWindow]];
+            NSPoint delta = NSMakePoint(newMouseLocation.x - originalMouseLocation.x,
+                                        newMouseLocation.y - originalMouseLocation.y);
+            
+            NSRect newFrame = originalFrame;
+            newFrame.origin.x += delta.x;
+            newFrame.origin.y += delta.y;
+            
+            [self setFrame:newFrame display:YES animate:NO];
+        }
+    }
+}
+
+- (void)center {
+	[self setFrame:NSOffsetRect(self.frame, NSMidX(self.screen.visibleFrame) - NSMidX(self.frame), 
+                                NSMidY(self.screen.visibleFrame) - NSMidY(self.frame)) display:YES];
+}
+
+- (BOOL)needsPanelToBecomeKey:(NSView *)v {
+	NSEnumerator *e;
+	if([v needsPanelToBecomeKey])
+		return YES;
+	e = [[v subviews] objectEnumerator];
+	while((v = [e nextObject]))
+		if([self needsPanelToBecomeKey:v])
+			return YES;
+	return NO;
+}
+
+@end
+
+@implementation TUIPanelFrame
+
+@synthesize nsView;
+
+- (id)initWithFrame:(CGRect)frame {
+    if((self = [super initWithFrame:frame])) {
+        self.nsView = [[TUINSView alloc] initWithFrame:NSMakeRect(0.f, 0.f, self.bounds.size.width,
+                                                                 self.bounds.size.height - TUIPanelTitlebarHeight)];
+        [nsView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
+        [nsView tui_setOpaque:NO];
+        [self addSubview:nsView];
+    } return self;
+}
+
+- (void)drawRect:(CGRect)dirtyRect {
+    NSBezierPath *path = [NSBezierPath bezierPathWithRoundedRect:NSInsetRect(self.bounds, 0.5f, 0.5f)
+                                                         xRadius:TUIPanelCornerRadius
+                                                         yRadius:TUIPanelCornerRadius];
+    NSGradient *borderGradient = [[NSGradient alloc] initWithColorsAndLocations:
+                                  [NSColor colorWithCalibratedWhite:1.00 alpha:0.925], 0.0,
+                                  [NSColor colorWithCalibratedWhite:0.95 alpha:0.925], 1.0, nil];
+    
+    [NSGraphicsContext saveGraphicsState];
+    [path addClip];
+    [borderGradient drawInBezierPath:path angle:-90];
+    [self drawTitleInRect:NSMakeRect(0.f, NSMaxY(self.bounds) - TUIPanelTitlebarHeight,
+                                     self.bounds.size.width, TUIPanelTitlebarHeight)];
+    [NSGraphicsContext restoreGraphicsState];
+    
+    [[NSColor colorWithCalibratedWhite:1.0 alpha:1.0] set];
+    [path stroke];
+}
+
+- (void)drawTitleInRect:(NSRect)titleBarRect {
+    NSString *title = [[self window] title];
+    if(!title) return;
+    
+    NSShadow *shadow = [NSShadow new];
+    [shadow setShadowColor:[NSColor whiteColor]];
+    [shadow setShadowOffset:NSMakeSize(0.f, -1.f)];
+    [shadow setShadowBlurRadius:2.0f];
+    
+    NSMutableParagraphStyle *style = [NSMutableParagraphStyle new];
+    [style setAlignment:NSCenterTextAlignment];
+    
+    NSDictionary *attributes = [NSDictionary dictionaryWithObjectsAndKeys:
+                                [NSColor colorWithDeviceWhite:0.15 alpha:0.8], NSForegroundColorAttributeName,
+                                [NSFont systemFontOfSize:12.f], NSFontAttributeName,
+                                shadow, NSShadowAttributeName,
+                                style, NSParagraphStyleAttributeName, nil];
+    
+    NSAttributedString *attrTitle = [[NSAttributedString alloc] initWithString:title attributes:attributes];
+    NSSize titleSize = attrTitle.size;
+    NSRect titleRect = NSMakeRect(0.f, NSMidY(titleBarRect) - (titleSize.height / 2.f),
+                                  titleBarRect.size.width, titleSize.height);
+    [attrTitle drawInRect:NSIntegralRect(titleRect)];
+}
+
+@end
+
+@implementation TUIWindowButtonCell
+
+- (void)drawWithFrame:(NSRect)cellFrame inView:(NSView *)controlView {
+    NSRect drawingRect = NSInsetRect(cellFrame, 1.5f, 1.5f);
+    drawingRect.origin.y = 0.5f;
+    NSRect dropShadowRect = drawingRect;
+    dropShadowRect.origin.y += 1.f;
+    
+    NSBezierPath *dropShadow = [NSBezierPath bezierPathWithOvalInRect:dropShadowRect];
+    [[NSColor colorWithDeviceWhite:1.0 alpha:0.6] set];
+    [dropShadow stroke];
+    
+    NSBezierPath *circle = [NSBezierPath bezierPathWithOvalInRect:drawingRect];
+    NSGradient *gradient = [[NSGradient alloc] initWithStartingColor:[NSColor colorWithDeviceWhite:0.7 alpha:1.0]
+                                                         endingColor:[NSColor colorWithDeviceWhite:0.5 alpha:1.0]];
+    [gradient drawInBezierPath:circle angle:270.f];
+    
+    if([self isHighlighted]) {
+        [[NSColor colorWithDeviceWhite:0.0 alpha:0.3] set];
+        [circle fill];
+    }
+    
+    NSBezierPath *cross = [NSBezierPath bezierPath];
+    CGFloat boxDimension = floor(drawingRect.size.width * cos(45.f)) - 1.0f;
+    CGFloat origin = round((drawingRect.size.width - boxDimension) / 2.f);
+    NSRect boxRect = NSMakeRect(1.f + origin, origin, boxDimension, boxDimension);
+    NSPoint bottomLeft = NSMakePoint(boxRect.origin.x, NSMaxY(boxRect));
+    NSPoint topRight = NSMakePoint(NSMaxX(boxRect), boxRect.origin.y);
+    NSPoint bottomRight = NSMakePoint(topRight.x, bottomLeft.y);
+    NSPoint topLeft = NSMakePoint(bottomLeft.x, topRight.y);
+    
+    [cross moveToPoint:bottomLeft];
+    [cross lineToPoint:topRight];
+    [cross moveToPoint:bottomRight];
+    [cross lineToPoint:topLeft];
+    
+    [[NSColor colorWithDeviceWhite:0.95 alpha:1.0] set];
+    [cross setLineWidth:2.f];
+    [cross stroke];
+    
+    NSShadow *shadow = [[NSShadow alloc] init];
+    [shadow setShadowColor:[NSColor colorWithDeviceWhite:0.3 alpha:0.2]];
+    [shadow setShadowBlurRadius:1.0f];
+    [shadow setShadowOffset:NSMakeSize(0.f, -1.f)];
+    
+    NSRect shadowRect = drawingRect;
+    shadowRect.size.height = origin;
+    [NSGraphicsContext saveGraphicsState];
+    [NSBezierPath clipRect:shadowRect];
+    [NSGraphicsContext saveGraphicsState];
+	
+	NSSize offset = shadow.shadowOffset;
+	NSSize originalOffset = offset;
+	CGFloat radius = shadow.shadowBlurRadius;
+    
+	NSRect bounds = NSInsetRect(circle.bounds, -(ABS(offset.width) + radius), -(ABS(offset.height) + radius));
+	offset.height += bounds.size.height;
+	shadow.shadowOffset = offset;
+    
+	NSAffineTransform *transform = [NSAffineTransform transform];
+	if([[NSGraphicsContext currentContext] isFlipped])
+		 [transform translateXBy:0 yBy:bounds.size.height];
+	else [transform translateXBy:0 yBy:-bounds.size.height];
+	
+	NSBezierPath *drawingPath = [NSBezierPath bezierPathWithRect:bounds];
+	[drawingPath setWindingRule:NSEvenOddWindingRule];
+	[drawingPath appendBezierPath:circle];
+	[drawingPath transformUsingAffineTransform:transform];
+	
+	[circle addClip];
+	[shadow set];
+	[[NSColor blackColor] set];
+	[drawingPath fill];
+	
+	shadow.shadowOffset = originalOffset;
+	[NSGraphicsContext restoreGraphicsState];
+    [NSGraphicsContext restoreGraphicsState];
+}
+
+@end


### PR DESCRIPTION
An NSPanel clone with auto-TUIView support that mimics the Messages.app 'Set Picture' window in 10.8.
It doesn't have sheet support yet, and I can't figure out for the life of me how to clip a view's corners (without CALayer intervention, if possible), and I think CGSPrivate died in 10.8, so I can't test window blurring.

But it works, it's non-obtrusive, and I use it in my app.
