### PR TITLE
Fixes for NSView clipping, animation, sizing, and text rendering

### DIFF
--- a/lib/Support/NSTextView+TUIExtensions.m
+++ b/lib/Support/NSTextView+TUIExtensions.m
@@ -19,9 +19,12 @@ static void fixedDrawRect (NSTextView *self, SEL _cmd, NSRect rect) {
     CGContextSetAllowsFontSubpixelQuantization(context, YES);
 
     CGContextSetShouldAntialias(context, YES);
-    CGContextSetShouldSmoothFonts(context, YES);
-    CGContextSetShouldSubpixelPositionFonts(context, YES);
-    CGContextSetShouldSubpixelQuantizeFonts(context, YES);
+
+	// TODO: SPAA seems to stop working when text fields and text views lose
+	// focus, so it's disabled for now.
+    CGContextSetShouldSmoothFonts(context, NO);
+    CGContextSetShouldSubpixelPositionFonts(context, NO);
+    CGContextSetShouldSubpixelQuantizeFonts(context, NO);
 
     if (self.superview) {
         // NSTextView likes to fall on non-integral points sometimes -- fix that

--- a/lib/Support/NSTextView+TUIExtensions.m
+++ b/lib/Support/NSTextView+TUIExtensions.m
@@ -1,8 +1,8 @@
 //
-//  NSTextView+TUIExtensions.m
+//	NSTextView+TUIExtensions.m
 //
-//  Created by Justin Spahr-Summers on 10.03.12.
-//  Copyright (c) 2012 Bitswift. All rights reserved.
+//	Created by Justin Spahr-Summers on 10.03.12.
+//	Copyright (c) 2012 Bitswift. All rights reserved.
 //
 
 #import "NSTextView+TUIExtensions.h"
@@ -11,36 +11,36 @@
 static void (*originalDrawRectIMP)(id, SEL, NSRect);
 
 static void fixedDrawRect (NSTextView *self, SEL _cmd, NSRect rect) {
-    CGContextRef context = [NSGraphicsContext currentContext].graphicsPort;
+	CGContextRef context = [NSGraphicsContext currentContext].graphicsPort;
 
-    CGContextSetAllowsAntialiasing(context, YES);
-    CGContextSetAllowsFontSmoothing(context, YES);
-    CGContextSetAllowsFontSubpixelPositioning(context, YES);
-    CGContextSetAllowsFontSubpixelQuantization(context, YES);
+	CGContextSetAllowsAntialiasing(context, YES);
+	CGContextSetAllowsFontSmoothing(context, YES);
+	CGContextSetAllowsFontSubpixelPositioning(context, YES);
+	CGContextSetAllowsFontSubpixelQuantization(context, YES);
 
-    CGContextSetShouldAntialias(context, YES);
+	CGContextSetShouldAntialias(context, YES);
 
 	// TODO: SPAA seems to stop working when text fields and text views lose
 	// focus, so it's disabled for now.
-    CGContextSetShouldSmoothFonts(context, NO);
-    CGContextSetShouldSubpixelPositionFonts(context, NO);
-    CGContextSetShouldSubpixelQuantizeFonts(context, NO);
+	CGContextSetShouldSmoothFonts(context, NO);
+	CGContextSetShouldSubpixelPositionFonts(context, NO);
+	CGContextSetShouldSubpixelQuantizeFonts(context, NO);
 
-    if (self.superview) {
-        // NSTextView likes to fall on non-integral points sometimes -- fix that
-        self.frame = [self.superview backingAlignedRect:self.frame options:NSAlignAllEdgesNearest];
-    }
+	if (self.superview) {
+		// NSTextView likes to fall on non-integral points sometimes -- fix that
+		self.frame = [self.superview backingAlignedRect:self.frame options:NSAlignAllEdgesNearest];
+	}
 
-    originalDrawRectIMP(self, _cmd, rect);
+	originalDrawRectIMP(self, _cmd, rect);
 }
 
 @implementation NSTextView (TUIExtensions)
 
 + (void)load {
-    Method drawRect = class_getInstanceMethod(self, @selector(drawRect:));
-    originalDrawRectIMP = (void (*)(id, SEL, NSRect))method_getImplementation(drawRect);
+	Method drawRect = class_getInstanceMethod(self, @selector(drawRect:));
+	originalDrawRectIMP = (void (*)(id, SEL, NSRect))method_getImplementation(drawRect);
 
-    class_replaceMethod(self, method_getName(drawRect), (IMP)&fixedDrawRect, method_getTypeEncoding(drawRect));
+	class_replaceMethod(self, method_getName(drawRect), (IMP)&fixedDrawRect, method_getTypeEncoding(drawRect));
 }
 
 @end

--- a/lib/Support/TUIAnimationManager.m
+++ b/lib/Support/TUIAnimationManager.m
@@ -1,8 +1,8 @@
 //
-//  TUIAnimationManager.m
+//	TUIAnimationManager.m
 //
-//  Created by Justin Spahr-Summers on 10.03.12.
-//  Copyright (c) 2012 Bitswift. All rights reserved.
+//	Created by Justin Spahr-Summers on 10.03.12.
+//	Copyright (c) 2012 Bitswift. All rights reserved.
 //
 
 #import "TUIAnimationManager.h"
@@ -11,7 +11,7 @@
  * Disables implicit AppKit animations on every run loop iteration.
  */
 static void mainRunLoopObserverCallback (CFRunLoopObserverRef observer, CFRunLoopActivity activity, void *info) {
-    [[NSAnimationContext currentContext] setDuration:0];
+	[[NSAnimationContext currentContext] setDuration:0];
 }
 
 @interface TUIAnimationManager ()
@@ -40,18 +40,18 @@ static void mainRunLoopObserverCallback (CFRunLoopObserverRef observer, CFRunLoo
 @synthesize mainRunLoopObserver = m_mainRunLoopObserver;
 
 - (void)setMainRunLoopObserver:(CFRunLoopObserverRef)observer {
-    if (observer == m_mainRunLoopObserver)
-        return;
+	if (observer == m_mainRunLoopObserver)
+		return;
 
-    if (m_mainRunLoopObserver) {
-        CFRunLoopRemoveObserver(CFRunLoopGetMain(), m_mainRunLoopObserver, kCFRunLoopCommonModes);
-        CFRelease(m_mainRunLoopObserver);
-    }
+	if (m_mainRunLoopObserver) {
+		CFRunLoopRemoveObserver(CFRunLoopGetMain(), m_mainRunLoopObserver, kCFRunLoopCommonModes);
+		CFRelease(m_mainRunLoopObserver);
+	}
 
-    if (observer)
-        CFRetain(observer);
+	if (observer)
+		CFRetain(observer);
 
-    m_mainRunLoopObserver = observer;
+	m_mainRunLoopObserver = observer;
 }
 
 #pragma mark Lifecycle
@@ -68,47 +68,47 @@ static void mainRunLoopObserverCallback (CFRunLoopObserverRef observer, CFRunLoo
 }
 
 + (TUIAnimationManager *)defaultManager; {
-    static id singleton = nil;
-    static dispatch_once_t pred;
+	static id singleton = nil;
+	static dispatch_once_t pred;
 
-    dispatch_once(&pred, ^{
-        singleton = [[self alloc] init];
-    });
+	dispatch_once(&pred, ^{
+		singleton = [[self alloc] init];
+	});
 
-    return singleton;
+	return singleton;
 }
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
 
-    self.mainRunLoopObserver = NULL;
+	self.mainRunLoopObserver = NULL;
 }
 
 #pragma mark Run Loop Observer
 
 - (void)registerRunLoopObserver; {
-    // set up an observer on the main run loop that can disable implicit
-    // animations
-    CFRunLoopObserverRef observer = CFRunLoopObserverCreate(
-        NULL,
-        kCFRunLoopBeforeTimers,
-        YES,
-        10000,
-        &mainRunLoopObserverCallback,
-        NULL
-    );
+	// set up an observer on the main run loop that can disable implicit
+	// animations
+	CFRunLoopObserverRef observer = CFRunLoopObserverCreate(
+		NULL,
+		kCFRunLoopBeforeTimers,
+		YES,
+		10000,
+		&mainRunLoopObserverCallback,
+		NULL
+	);
 
-    CFRunLoopAddObserver(CFRunLoopGetMain(), observer, kCFRunLoopCommonModes);
+	CFRunLoopAddObserver(CFRunLoopGetMain(), observer, kCFRunLoopCommonModes);
 
-    self.mainRunLoopObserver = observer;
-    CFRelease(observer);
+	self.mainRunLoopObserver = observer;
+	CFRelease(observer);
 }
 
 #pragma mark Notifications
 
 - (void)applicationDidFinishLaunchingNotification:(NSNotification *)notification; {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:notification.name object:nil];
-    [self registerRunLoopObserver];
+	[[NSNotificationCenter defaultCenter] removeObserver:self name:notification.name object:nil];
+	[self registerRunLoopObserver];
 }
 
 @end

--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -630,6 +630,8 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	opaque = YES;
 
 	_maskLayer = [CAShapeLayer layer];
+	_maskLayer.frame = self.bounds;
+	_maskLayer.autoresizingMask = kCALayerWidthSizable | kCALayerHeightSizable;
 
 	// enable layer-backing for this view
 	self.wantsLayer = YES;

--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -704,10 +704,13 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 }
 
 - (void)recalculateNSViewOrdering; {
+	NSAssert([NSThread isMainThread], @"");
 	[self.appKitHostView sortSubviewsUsingFunction:&compareNSViewOrdering context:NULL];
 }
 
 - (void)recalculateNSViewClipping; {
+	NSAssert([NSThread isMainThread], @"");
+
 	#if !ENABLE_NSVIEW_CLIPPING
 	return;
 	#endif
@@ -721,9 +724,9 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 
 		CALayer *focusRingLayer = [self focusRingLayerForView:view];
 		if (focusRingLayer) {
-			id<TUIBridgedScrollView> clippingView = [hostView ancestorScrollView];
+			id<TUIBridgedScrollView> clippingView = hostView.ancestorScrollView;
 
-			if (clippingView) {
+			if (clippingView && self.ancestorScrollView != clippingView) {
 				// set up a mask on the focus ring that clips to any ancestor scroll views
 				CAShapeLayer *maskLayer = (id)focusRingLayer.mask;
 				if (![maskLayer isKindOfClass:[CAShapeLayer class]]) {

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -145,6 +145,8 @@ static NSMutableArray *AnimationStack = nil;
 
 + (void)beginAnimations:(NSString *)animationID context:(void *)context
 {
+	[NSAnimationContext beginGrouping];
+
 	TUIViewAnimation *animation = [[TUIViewAnimation alloc] init];
 	animation.context = context;
 	animation.animationID = animationID;
@@ -160,6 +162,7 @@ static NSMutableArray *AnimationStack = nil;
 + (void)commitAnimations
 {
 	[[self _animationStack] removeLastObject];
+	[NSAnimationContext endGrouping];
 	
 //	NSLog(@"--- %d", [[self _animationStack] count]);
 }
@@ -188,7 +191,9 @@ static CGFloat SlomoTime()
 
 + (void)setAnimationDuration:(NSTimeInterval)duration
 {
-	[self _currentAnimation].basicAnimation.duration = duration * SlomoTime();
+	duration *= SlomoTime();
+	[self _currentAnimation].basicAnimation.duration = duration;
+	[NSAnimationContext currentContext].duration = duration;
 }
 
 + (void)setAnimationDelay:(NSTimeInterval)delay                    // default = 0.0

--- a/lib/UIKit/TUIView.m
+++ b/lib/UIKit/TUIView.m
@@ -15,13 +15,13 @@
  */
 
 #import <pthread.h>
-#import "TUIView.h"
-#import "TUIKit.h"
+#import "TUILayoutManager.h"
 #import "TUINSWindow.h"
 #import "TUITextRenderer.h"
 #import "TUIView+Private.h"
+#import "TUIView+TUIBridgedView.h"
+#import "TUIView.h"
 #import "TUIViewController.h"
-#import "TUILayoutManager.h"
 
 NSString * const TUIViewWillMoveToWindowNotification = @"TUIViewWillMoveToWindowNotification";
 NSString * const TUIViewDidMoveToWindowNotification = @"TUIViewDidMoveToWindowNotification";

--- a/lib/UIKit/TUIViewNSViewContainer.m
+++ b/lib/UIKit/TUIViewNSViewContainer.m
@@ -108,8 +108,8 @@
 
 #pragma mark Lifecycle
 
-- (id)init {
-	self = [super init];
+- (id)initWithFrame:(CGRect)frame {
+	self = [super initWithFrame:frame];
 	if (!self)
 		return nil;
 
@@ -124,12 +124,11 @@
 - (id)initWithNSView:(NSView *)view; {
 	NSAssert1([NSThread isMainThread], @"%s should only be called from the main thread", __func__);
 
-	self = [self init];
+	self = [self initWithFrame:view.frame];
 	if (!self)
 		return nil;
 
 	self.rootView = view;
-	self.frame = view.frame;
 	return self;
 }
 

--- a/lib/UIKit/TUIViewNSViewContainer.m
+++ b/lib/UIKit/TUIViewNSViewContainer.m
@@ -279,6 +279,16 @@
 	return cellSize;
 }
 
+- (void)sizeToFit {
+	if ([self.rootView respondsToSelector:@selector(sizeToFit)]) {
+		[self.rootView performSelector:@selector(sizeToFit)];
+
+		self.bounds = self.rootView.bounds;
+	} else {
+		[super sizeToFit];
+	}
+}
+
 #pragma mark NSObject overrides
 
 - (NSString *)description {

--- a/lib/UIKit/TUIViewNSViewContainer.m
+++ b/lib/UIKit/TUIViewNSViewContainer.m
@@ -82,6 +82,16 @@
 	return [self convertRect:self.bounds toView:self.ancestorTUINSView.rootView];
 }
 
+- (void)setFrame:(CGRect)frame {
+	[super setFrame:frame];
+	[self synchronizeNSViewGeometry];
+}
+
+- (void)setBounds:(CGRect)bounds {
+	[super setBounds:bounds];
+	[self synchronizeNSViewGeometry];
+}
+
 - (void)setCenter:(CGPoint)center {
 	[super setCenter:center];
 	[self synchronizeNSViewGeometry];


### PR DESCRIPTION
As the title implies, this contains mostly odds-and-ends fixes from using the AppKit bridging code in a real application.

Most notable in this pull request is the fix for how `NSView` clipping paths are calculated. Previously, focus rings would mess up the path by adding huge regions; now, the clipping path is always tightly wrapped around the focus ring, and goes no further.
