### PR TITLE
Fix partial redrawing of views on retina displays

### DIFF
--- a/lib/UIKit/TUIView.m
+++ b/lib/UIKit/TUIView.m
@@ -363,13 +363,14 @@ static void TUISetCurrentContextScaleFactor(CGFloat s)
 	void (^drawBlock)(void) = ^{
 		CGContextRef context = [self _CGContext];
 		TUIGraphicsPushContext(context);
-		if (_viewFlags.clearsContextBeforeDrawing) {
-			CGContextClearRect(context, rectToDraw);
-		}
 
 		CGFloat scale = [self.layer respondsToSelector:@selector(contentsScale)] ? self.layer.contentsScale : 1.0f;
 		TUISetCurrentContextScaleFactor(scale);
 		CGContextScaleCTM(context, scale, scale);
+
+		if (_viewFlags.clearsContextBeforeDrawing) {
+			CGContextClearRect(context, rectToDraw);
+		}
 
 		CGContextSetAllowsAntialiasing(context, true);
 		CGContextSetShouldAntialias(context, true);


### PR DESCRIPTION
Previously, using `setNeedsDisplayInRect:` would result in the wrong rectangle being cleared (when `clearsContextBeforeDrawing` is `YES`), but the correct rectangle passed to `drawRect:`. This fixes the former, so that the two rectangles now align.
