### PR TITLE
Handle -[NSView isFlipped] when rendering the rootView of a TUIViewNSViewContainer

### DIFF
--- a/lib/UIKit/TUIViewNSViewContainer.m
+++ b/lib/UIKit/TUIViewNSViewContainer.m
@@ -163,7 +163,15 @@
 	}
 
 	CGContextRef context = [NSGraphicsContext currentContext].graphicsPort;
+	CGContextSaveGState(context);
+
+	if ([self.rootView isFlipped]) {
+		CGContextTranslateCTM(context, 0, self.bounds.size.height);
+		CGContextScaleCTM(context, 1, -1);
+	}
+
 	[self.rootView.layer renderInContext:context];
+	CGContextRestoreGState(context);
 }
 
 - (void)startRenderingContainedView; {


### PR DESCRIPTION
This issue is only noticeable during animations. To test:
1. Run the ExampleProject.
2. Type something into the text field of one of the cells.
3. Drag one of the cell's neighbors around it repeatedly, and watch the text field animate beneath.
