### PR TITLE
Implement retina-aware image context creation

### DIFF
--- a/lib/UIKit/TUICGAdditions.h
+++ b/lib/UIKit/TUICGAdditions.h
@@ -57,6 +57,7 @@ extern void TUIGraphicsPopContext(void);
 extern NSImage *TUIGraphicsContextGetImage(CGContextRef ctx);
 
 extern void TUIGraphicsBeginImageContext(CGSize size);
+// as in the iOS docs, "if you specify a value of 0.0, the scale factor is set to the scale factor of the device’s main screen."
 extern void TUIGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGFloat scale);
 extern NSImage *TUIGraphicsGetImageFromCurrentImageContext(void);
 extern void TUIGraphicsEndImageContext(void); 

--- a/lib/UIKit/TUICGAdditions.m
+++ b/lib/UIKit/TUICGAdditions.m
@@ -199,24 +199,31 @@ NSImage *TUIGraphicsContextGetImage(CGContextRef ctx)
 	CGSize size = CGSizeMake(CGImageGetWidth(CGImage), CGImageGetHeight(CGImage));
 	NSImage *image = [[NSImage alloc] initWithCGImage:CGImage size:size];
 	CGImageRelease(CGImage);
-
+    
 	return image;
 }
 
 void TUIGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGFloat scale)
 {
+    // as in the iOS docs, "if you specify a value of 0.0, the scale
+    // factor is set to the scale factor of the device’s main screen."
+    if (scale == 0.0) {
+        scale = [[NSScreen mainScreen] backingScaleFactor];
+    }
+    
 	size.width *= scale;
 	size.height *= scale;
 	if(size.width < 1) size.width = 1;
 	if(size.height < 1) size.height = 1;
 	CGContextRef ctx = TUICreateGraphicsContextWithOptions(size, opaque);
+    CGContextScaleCTM(ctx, scale, scale);
 	TUIGraphicsPushContext(ctx);
 	CGContextRelease(ctx);
 }
 
 void TUIGraphicsBeginImageContext(CGSize size)
 {
-	TUIGraphicsBeginImageContextWithOptions(size, NO, 1.0f);
+	TUIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
 }
 
 NSImage *TUIGraphicsGetImageFromCurrentImageContext(void)
@@ -230,7 +237,7 @@ NSImage *TUIGraphicsGetImageForView(TUIView *view)
 	[view.layer renderInContext:TUIGraphicsGetCurrentContext()];
 	NSImage *image = TUIGraphicsGetImageFromCurrentImageContext();
 	TUIGraphicsEndImageContext();
-
+    
 	return image;
 }
 
@@ -245,7 +252,7 @@ NSImage *TUIGraphicsDrawAsImage(CGSize size, void(^draw)(void))
 	draw();
 	NSImage *image = TUIGraphicsGetImageFromCurrentImageContext();
 	TUIGraphicsEndImageContext();
-
+    
 	return image;
 }
 

--- a/lib/UIKit/TUICGAdditions.m
+++ b/lib/UIKit/TUICGAdditions.m
@@ -205,8 +205,6 @@ NSImage *TUIGraphicsContextGetImage(CGContextRef ctx)
 
 void TUIGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGFloat scale)
 {
-    // as in the iOS docs, "if you specify a value of 0.0, the scale
-    // factor is set to the scale factor of the device’s main screen."
     if (scale == 0.0) {
         scale = [[NSScreen mainScreen] backingScaleFactor];
     }

--- a/lib/UIKit/TUICGAdditions.m
+++ b/lib/UIKit/TUICGAdditions.m
@@ -205,16 +205,16 @@ NSImage *TUIGraphicsContextGetImage(CGContextRef ctx)
 
 void TUIGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGFloat scale)
 {
-    if (scale == 0.0) {
-        scale = [[NSScreen mainScreen] backingScaleFactor];
-    }
+	if (scale == 0.0) {
+		scale = [[NSScreen mainScreen] backingScaleFactor];
+	}
     
 	size.width *= scale;
 	size.height *= scale;
 	if(size.width < 1) size.width = 1;
 	if(size.height < 1) size.height = 1;
 	CGContextRef ctx = TUICreateGraphicsContextWithOptions(size, opaque);
-    CGContextScaleCTM(ctx, scale, scale);
+	CGContextScaleCTM(ctx, scale, scale);
 	TUIGraphicsPushContext(ctx);
 	CGContextRelease(ctx);
 }


### PR DESCRIPTION
Also, I allowed for the passing in of `0` to base the scale on the current screen's scale, just like on iOS.
