### PR TITLE
Fix TUIButton title not drawing

### DIFF
--- a/lib/UIKit/TUIButton.m
+++ b/lib/UIKit/TUIButton.m
@@ -214,19 +214,19 @@ static CGRect ButtonRectCenteredInRect(CGRect a, CGRect b)
 	
 	NSString *title = self.currentTitle;
 	if(title != nil) {
-		_titleView.text = title;
+		self.titleLabel.text = title;
 	}
 	
 	NSColor *color = self.currentTitleColor;
 	if(color != nil) {
-		_titleView.textColor = color;
+		self.titleLabel.textColor = color;
 	}
 	
 	NSColor *shadowColor = self.currentTitleShadowColor;
 	// they may have manually set the renderer's shadow color, in which case we 
 	// don't want to reset it to nothing
 	if(shadowColor != nil) {
-		_titleView.renderer.shadowColor = shadowColor;
+		self.titleLabel.renderer.shadowColor = shadowColor;
 	}
 	
 	CGContextRef ctx = TUIGraphicsGetCurrentContext();
@@ -236,8 +236,8 @@ static CGRect ButtonRectCenteredInRect(CGRect a, CGRect b)
 		CGContextSetAlpha(ctx, 0.5);
 	CGRect titleFrame = self.bounds;
 	titleFrame.size.width -= (_titleEdgeInsets.left + _titleEdgeInsets.right);
-	_titleView.frame = titleFrame;
-	[_titleView drawRect:_titleView.bounds];
+	self.titleLabel.frame = titleFrame;
+	[self.titleLabel drawRect:self.titleLabel.bounds];
 	CGContextRestoreGState(ctx);
 }
 

--- a/lib/UIKit/TUIControl.m
+++ b/lib/UIKit/TUIControl.m
@@ -41,7 +41,10 @@
 
 - (void)setEnabled:(BOOL)e
 {
+	[self _stateWillChange];
 	_controlFlags.disabled = !e;
+	[self _stateDidChange];
+	[self setNeedsDisplay];
 }
 
 - (BOOL)isTracking

--- a/lib/UIKit/TUIControl.m
+++ b/lib/UIKit/TUIControl.m
@@ -127,6 +127,10 @@
 - (void)mouseDown:(NSEvent *)event
 {
 	[super mouseDown:event];
+
+	if (self.state & TUIControlStateDisabled) {
+		return;
+	}
 	
 	// handle state change
 	[self _stateWillChange];
@@ -147,6 +151,10 @@
 - (void)mouseUp:(NSEvent *)event
 {
 	[super mouseUp:event];
+
+	if (self.state & TUIControlStateDisabled) {
+		return;
+	}
 	
 	// handle state change
 	[self _stateWillChange];


### PR DESCRIPTION
The original issue was described in github/twui#46. Here I replace the ivar `_titleView` with `self.titleLabel` in `draw:` method to ensure `_titleView` is non-nil.

Also, I found that changing the TUIButton's "enabled" property didn't update the button's UI. And when the button is disabled, a mouse down event will make the button highlighted, which shouldn't. So I've added two more commits to fix these.
