### PR TITLE
Create a 1x image context with TUIGraphicsBeginImageContext()

### DIFF
--- a/lib/UIKit/TUICGAdditions.m
+++ b/lib/UIKit/TUICGAdditions.m
@@ -221,7 +221,7 @@ void TUIGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGFloat s
 
 void TUIGraphicsBeginImageContext(CGSize size)
 {
-	TUIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
+	TUIGraphicsBeginImageContextWithOptions(size, NO, 1.0);
 }
 
 NSImage *TUIGraphicsGetImageFromCurrentImageContext(void)


### PR DESCRIPTION
This partially reverts 737f2048ccc24066fa953088cf1e23e819c11131, to keep the previous behavior of the function. Passing 0 to `TUIGraphicsBeginImageContextWithOptions` still works.

CC @jwilling
