### PR TITLE
Retina TUIProgressBar Fixes

### DIFF
--- a/lib/UIKit/TUIProgressBar.m
+++ b/lib/UIKit/TUIProgressBar.m
@@ -24,6 +24,14 @@ CGFloat const GHUIProgressBarBarberPoleAnimationDuration = 5.0;
 CGFloat const GHUIProgressBarBarberPolePatternWidth = 16.0;
 CGFloat const GHUIProgressBarIdealTrackHeight = 12.0;
 
+// Simple struct used to pass information from the overlay drawing into the
+// pattern that it uses.
+//
+// bounds - the bounds of the pattern segment
+// contentsScale - the backing contents scale, necessary to correctly scale the
+// drawing of the pattern to match the backing scale factor.
+//
+
 struct TUIProgressBarPatternInfoStruct {
 	CGRect bounds;
 	CGFloat contentsScale;

--- a/lib/UIKit/TUIProgressBar.m
+++ b/lib/UIKit/TUIProgressBar.m
@@ -247,7 +247,7 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 
 - (CGPoint)farLeftAnimatingPosition
 {
-	return CGPointMake((NSMidX(self.animationView.superview.bounds) - (NSWidth(self.animationView.superview.bounds) / 2.0)) + 1.0, NSMidY(self.animationView.superview.bounds));
+	return CGPointMake((NSMidX(self.animationView.superview.bounds) - (NSWidth(self.animationView.superview.bounds) / 2.0)) + 9.0, NSMidY(self.animationView.superview.bounds));
 }
 
 - (CGPoint)farRightAnimatingPosition

--- a/lib/UIKit/TUIProgressBar.m
+++ b/lib/UIKit/TUIProgressBar.m
@@ -354,11 +354,11 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 
 void GHUIProgressPatternDrawCallback(void *info, CGContextRef context)
 {
-	const struct TUIProgressBarPatternInfoStruct passedInfo = *(struct TUIProgressBarPatternInfoStruct *)info;
-	CGFloat contentsScale = passedInfo.contentsScale;
+	const struct TUIProgressBarPatternInfoStruct *passedInfo = info;
+	CGFloat contentsScale = passedInfo->contentsScale;
 	CGContextScaleCTM(context, contentsScale, contentsScale);
 	
-	CGRect bounds = passedInfo.bounds;
+	CGRect bounds = passedInfo->bounds;
 	CGContextSetBlendMode([[NSGraphicsContext currentContext] graphicsPort], kCGBlendModeOverlay);
 	
 	CGMutablePathRef fillPath = CGPathCreateMutable();

--- a/lib/UIKit/TUIProgressBar.m
+++ b/lib/UIKit/TUIProgressBar.m
@@ -301,10 +301,11 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 		CGContextSetFillColorSpace(currentContext, patternColorSpace);
 		CGColorSpaceRelease(patternColorSpace);
 		
+		NSDictionary *infoDict = @{@"bounds" : [NSValue valueWithRect:patternBounds], @"contentsScale" : @(view.layer.contentsScale)};
 		const struct CGPatternCallbacks callbacks = {0, &GHUIProgressPatternDrawCallback, NULL};
-		CGPatternRef pattern = CGPatternCreate((__bridge void *)[NSValue valueWithRect:patternBounds], patternBounds, CGAffineTransformIdentity, GHUIProgressBarBarberPolePatternWidth, NSHeight(view.bounds), kCGPatternTilingConstantSpacing, true, &callbacks);
+		CGPatternRef pattern = CGPatternCreate((__bridge void *)infoDict, patternBounds, CGAffineTransformIdentity, (GHUIProgressBarBarberPolePatternWidth * self.layer.contentsScale), (NSHeight(view.bounds) * self.layer.contentsScale), kCGPatternTilingConstantSpacing, true, &callbacks);
 		CGFloat components = 1.0; //It's a coloured pattern so just alpha is fine
-		CGContextSetFillPattern(currentContext, pattern, &components); 
+		CGContextSetFillPattern(currentContext, pattern, &components);
 		CGContextFillRect(currentContext, view.bounds);
 		CGPatternRelease(pattern);
 		[NSGraphicsContext restoreGraphicsState];
@@ -341,7 +342,14 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 void GHUIProgressPatternDrawCallback(void *info, CGContextRef context)
 {
 	[NSGraphicsContext saveGraphicsState];
-	CGRect bounds = [(__bridge NSValue *)info rectValue];
+	NSGraphicsContext *nsContext = [NSGraphicsContext graphicsContextWithGraphicsPort:context flipped:NO];
+	[NSGraphicsContext setCurrentContext:nsContext];
+	
+	NSDictionary *infoDict = (__bridge NSDictionary *)info;
+	CGFloat contentsScale = [[infoDict objectForKey:@"contentsScale"] doubleValue];
+	CGContextScaleCTM(context, contentsScale, contentsScale);
+	
+	CGRect bounds = [[infoDict objectForKey:@"bounds"] rectValue];
 	CGContextSetBlendMode([[NSGraphicsContext currentContext] graphicsPort], kCGBlendModeOverlay);
 	[[NSColor colorWithCalibratedWhite:1.0 alpha:0.24] set];
 

--- a/lib/UIKit/TUIProgressBar.m
+++ b/lib/UIKit/TUIProgressBar.m
@@ -252,7 +252,7 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 
 - (CGPoint)farLeftAnimatingPosition
 {
-	return CGPointMake((NSMidX(self.animationView.superview.bounds) - (NSWidth(self.animationView.superview.bounds) / 2.0)) + 9.0, NSMidY(self.animationView.superview.bounds));
+	return CGPointMake(NSMinX(self.animationView.superview.bounds) + 9.0, NSMidY(self.animationView.superview.bounds));
 }
 
 - (CGPoint)farRightAnimatingPosition

--- a/lib/UIKit/TUIProgressBar.m
+++ b/lib/UIKit/TUIProgressBar.m
@@ -24,7 +24,7 @@ CGFloat const GHUIProgressBarBarberPoleAnimationDuration = 5.0;
 CGFloat const GHUIProgressBarBarberPolePatternWidth = 16.0;
 CGFloat const GHUIProgressBarIdealTrackHeight = 12.0;
 
-struct infoStruct {
+struct TUIProgressBarPatternInfoStruct {
 	CGRect bounds;
 	CGFloat contentsScale;
 };
@@ -306,7 +306,7 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 		CGContextSetFillColorSpace(currentContext, patternColorSpace);
 		CGColorSpaceRelease(patternColorSpace);
 		
-		const struct infoStruct info = {.bounds = patternBounds, .contentsScale = view.layer.contentsScale};
+		const struct TUIProgressBarPatternInfoStruct info = {.bounds = patternBounds, .contentsScale = view.layer.contentsScale};
 		const struct CGPatternCallbacks callbacks = {0, &GHUIProgressPatternDrawCallback, NULL};
 		CGPatternRef pattern = CGPatternCreate((void *)&info, patternBounds, CGAffineTransformIdentity, (GHUIProgressBarBarberPolePatternWidth * self.layer.contentsScale), (NSHeight(view.bounds) * self.layer.contentsScale), kCGPatternTilingConstantSpacing, true, &callbacks);
 		CGFloat components = 1.0; //It's a coloured pattern so just alpha is fine
@@ -346,7 +346,7 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 
 void GHUIProgressPatternDrawCallback(void *info, CGContextRef context)
 {
-	const struct infoStruct passedInfo = *(struct infoStruct *)info;
+	const struct TUIProgressBarPatternInfoStruct passedInfo = *(struct TUIProgressBarPatternInfoStruct *)info;
 	CGFloat contentsScale = passedInfo.contentsScale;
 	CGContextScaleCTM(context, contentsScale, contentsScale);
 	

--- a/lib/UIKit/TUIProgressBar.m
+++ b/lib/UIKit/TUIProgressBar.m
@@ -24,6 +24,11 @@ CGFloat const GHUIProgressBarBarberPoleAnimationDuration = 5.0;
 CGFloat const GHUIProgressBarBarberPolePatternWidth = 16.0;
 CGFloat const GHUIProgressBarIdealTrackHeight = 12.0;
 
+struct infoStruct {
+	CGRect bounds;
+	CGFloat contentsScale;
+};
+
 void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 
 @interface TUIProgressBar ()
@@ -301,9 +306,9 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 		CGContextSetFillColorSpace(currentContext, patternColorSpace);
 		CGColorSpaceRelease(patternColorSpace);
 		
-		NSDictionary *infoDict = @{@"bounds" : [NSValue valueWithRect:patternBounds], @"contentsScale" : @(view.layer.contentsScale)};
+		const struct infoStruct info = {patternBounds, view.layer.contentsScale};
 		const struct CGPatternCallbacks callbacks = {0, &GHUIProgressPatternDrawCallback, NULL};
-		CGPatternRef pattern = CGPatternCreate((__bridge void *)infoDict, patternBounds, CGAffineTransformIdentity, (GHUIProgressBarBarberPolePatternWidth * self.layer.contentsScale), (NSHeight(view.bounds) * self.layer.contentsScale), kCGPatternTilingConstantSpacing, true, &callbacks);
+		CGPatternRef pattern = CGPatternCreate((void *)&info, patternBounds, CGAffineTransformIdentity, (GHUIProgressBarBarberPolePatternWidth * self.layer.contentsScale), (NSHeight(view.bounds) * self.layer.contentsScale), kCGPatternTilingConstantSpacing, true, &callbacks);
 		CGFloat components = 1.0; //It's a coloured pattern so just alpha is fine
 		CGContextSetFillPattern(currentContext, pattern, &components);
 		CGContextFillRect(currentContext, view.bounds);
@@ -341,11 +346,11 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 
 void GHUIProgressPatternDrawCallback(void *info, CGContextRef context)
 {
-	NSDictionary *infoDict = (__bridge NSDictionary *)info;
-	CGFloat contentsScale = [[infoDict objectForKey:@"contentsScale"] doubleValue];
+	const struct infoStruct passedInfo = *(struct infoStruct *)info;
+	CGFloat contentsScale = passedInfo.contentsScale;
 	CGContextScaleCTM(context, contentsScale, contentsScale);
 	
-	CGRect bounds = [[infoDict objectForKey:@"bounds"] rectValue];
+	CGRect bounds = passedInfo.bounds;
 	CGContextSetBlendMode([[NSGraphicsContext currentContext] graphicsPort], kCGBlendModeOverlay);
 	
 	CGMutablePathRef fillPath = CGPathCreateMutable();

--- a/lib/UIKit/TUIProgressBar.m
+++ b/lib/UIKit/TUIProgressBar.m
@@ -21,7 +21,7 @@
 NSString *GHUIProgressBarSetNeedsDisplayObservationContext = @"GHUIProgressBarSetNeedsDisplayObservationContext";
 
 CGFloat const GHUIProgressBarBarberPoleAnimationDuration = 5.0;
-CGFloat const GHUIProgressBarBarberPolePatternWidth = 8.0;
+CGFloat const GHUIProgressBarBarberPolePatternWidth = 16.0;
 CGFloat const GHUIProgressBarIdealTrackHeight = 12.0;
 
 void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
@@ -341,34 +341,27 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 
 void GHUIProgressPatternDrawCallback(void *info, CGContextRef context)
 {
-	[NSGraphicsContext saveGraphicsState];
-	NSGraphicsContext *nsContext = [NSGraphicsContext graphicsContextWithGraphicsPort:context flipped:NO];
-	[NSGraphicsContext setCurrentContext:nsContext];
-	
 	NSDictionary *infoDict = (__bridge NSDictionary *)info;
 	CGFloat contentsScale = [[infoDict objectForKey:@"contentsScale"] doubleValue];
 	CGContextScaleCTM(context, contentsScale, contentsScale);
 	
 	CGRect bounds = [[infoDict objectForKey:@"bounds"] rectValue];
 	CGContextSetBlendMode([[NSGraphicsContext currentContext] graphicsPort], kCGBlendModeOverlay);
-	[[NSColor colorWithCalibratedWhite:1.0 alpha:0.24] set];
-
-	// I have _no_ idea why the save/restore of graphics state is fucking this up… working around it with this crap for now
-	CGFloat previousLineWidth = [NSBezierPath defaultLineWidth];
-	NSLineCapStyle previousLineCapStyle = [NSBezierPath defaultLineCapStyle];
-	//
 	
-	[NSBezierPath setDefaultLineWidth:3.0];
-	[NSBezierPath setDefaultLineCapStyle:NSSquareLineCapStyle];
-	[NSBezierPath strokeLineFromPoint:NSMakePoint(NSMinX(bounds), NSMidY(bounds)) toPoint:NSMakePoint(NSMaxX(bounds), NSMaxY(bounds))];
-	[NSBezierPath strokeLineFromPoint:NSMakePoint(NSMidX(bounds), NSMinY(bounds)) toPoint:NSMakePoint((NSMaxX(bounds) + 1.0), NSMidY(bounds))];
+	CGMutablePathRef fillPath = CGPathCreateMutable();
+	CGPathMoveToPoint(fillPath, NULL, NSMinX(bounds), NSMinY(bounds));
+	CGPathAddLineToPoint(fillPath, NULL, NSMidX(bounds), NSMaxY(bounds));
+	CGPathAddLineToPoint(fillPath, NULL, NSMaxX(bounds), NSMaxY(bounds));
+	CGPathAddLineToPoint(fillPath, NULL, NSMidX(bounds), NSMinY(bounds));
+	CGPathCloseSubpath(fillPath);
 	
-	// Fuck AppKit
-	[NSBezierPath setDefaultLineWidth:previousLineWidth];
-	[NSBezierPath setDefaultLineCapStyle:previousLineCapStyle];
-	//
+	CGContextAddPath(context, fillPath);
+	CGColorRef fillColor = CGColorCreateGenericGray(1.0, 0.24);
+	CGContextSetFillColorWithColor(context, fillColor);
+	CGColorRelease(fillColor);
+	CGContextFillPath(context);
 	
-	[NSGraphicsContext restoreGraphicsState];
+	CGPathRelease(fillPath);
 }
 
 @end

--- a/lib/UIKit/TUIProgressBar.m
+++ b/lib/UIKit/TUIProgressBar.m
@@ -306,7 +306,7 @@ void GHUIProgressPatternDrawCallback(void *info, CGContextRef context);
 		CGContextSetFillColorSpace(currentContext, patternColorSpace);
 		CGColorSpaceRelease(patternColorSpace);
 		
-		const struct infoStruct info = {patternBounds, view.layer.contentsScale};
+		const struct infoStruct info = {.bounds = patternBounds, .contentsScale = view.layer.contentsScale};
 		const struct CGPatternCallbacks callbacks = {0, &GHUIProgressPatternDrawCallback, NULL};
 		CGPatternRef pattern = CGPatternCreate((void *)&info, patternBounds, CGAffineTransformIdentity, (GHUIProgressBarBarberPolePatternWidth * self.layer.contentsScale), (NSHeight(view.bounds) * self.layer.contentsScale), kCGPatternTilingConstantSpacing, true, &callbacks);
 		CGFloat components = 1.0; //It's a coloured pattern so just alpha is fine


### PR DESCRIPTION
There were a couple of pieces to this puzzle.
- The pattern I was using was completely brainfucked. I went back to the start and fixed it.
- We need to scale the pattern context to match the backing scale factor.

This does both of these and now `TUIProgressBar` (the blue style especially) looks bloody sexy on retina. 
