### PR TITLE
Improved scrolling behaviour of Example app.

### DIFF
--- a/ExampleProject/ConcordeExample/ExampleView.m
+++ b/ExampleProject/ConcordeExample/ExampleView.m
@@ -41,6 +41,7 @@
 		 we don't, so it could potentially save us some rendering costs.
 		 */
 		_tableView = [[TUITableView alloc] initWithFrame:b];
+		[_tableView setAlwaysBounceVertical: YES];
 		_tableView.autoresizingMask = TUIViewAutoresizingFlexibleSize;
 		_tableView.dataSource = self;
 		_tableView.delegate = self;

--- a/ExampleProject/ConcordeExample/ExampleView.m
+++ b/ExampleProject/ConcordeExample/ExampleView.m
@@ -41,11 +41,11 @@
 		 we don't, so it could potentially save us some rendering costs.
 		 */
 		_tableView = [[TUITableView alloc] initWithFrame:b];
-		_tableView.alwaysBounceVertical = TRUE;
+		_tableView.alwaysBounceVertical = YES;
 		_tableView.autoresizingMask = TUIViewAutoresizingFlexibleSize;
 		_tableView.dataSource = self;
 		_tableView.delegate = self;
-		_tableView.maintainContentOffsetAfterReload = TRUE;
+		_tableView.maintainContentOffsetAfterReload = YES;
 		[self addSubview:_tableView];
 		
 		_tabBar = [[ExampleTabBar alloc] initWithNumberOfTabs:5];

--- a/ExampleProject/ConcordeExample/ExampleView.m
+++ b/ExampleProject/ConcordeExample/ExampleView.m
@@ -41,7 +41,7 @@
 		 we don't, so it could potentially save us some rendering costs.
 		 */
 		_tableView = [[TUITableView alloc] initWithFrame:b];
-		[_tableView setAlwaysBounceVertical: YES];
+		_tableView.alwaysBounceVertical = TRUE;
 		_tableView.autoresizingMask = TUIViewAutoresizingFlexibleSize;
 		_tableView.dataSource = self;
 		_tableView.delegate = self;


### PR DESCRIPTION
Enabled vertical bouncing even when content fits into container.
However, IMO this should be the default behaviour for all
vertically-scrolling views or lists, so the problem should actually be
fixed at the source, in TUIScrollView.
