### PR TITLE
Clean up TUIViewAnimation, add +isInAnimationContext

### DIFF
--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -18,17 +18,6 @@
 #import "TUICAAction.h"
 
 @interface TUIViewAnimation : NSObject <CAAction>
-{
-	void *context;
-	NSString *animationID;
-
-	id __unsafe_unretained delegate;
-	SEL animationWillStartSelector;
-	SEL animationDidStopSelector;
-	void (^animationCompletionBlock)(BOOL finished);
-	
-	CABasicAnimation *basicAnimation;
-}
 
 @property (nonatomic, assign) void *context;
 @property (nonatomic, copy) NSString *animationID;
@@ -43,16 +32,6 @@
 @end
 
 @implementation TUIViewAnimation
-
-@synthesize context;
-@synthesize animationID;
-
-@synthesize delegate;
-@synthesize animationWillStartSelector;
-@synthesize animationDidStopSelector;
-@synthesize animationCompletionBlock;
-
-@synthesize basicAnimation;
 
 - (id)init
 {

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -24,7 +24,7 @@ static TUIViewAnimation *TUIViewCurrentAnimation;
 static BOOL TUIViewAnimationsEnabled = YES;
 static BOOL TUIViewAnimateContents = NO;
 
-static CGFloat SlomoTime() {
+static CGFloat TUIViewAnimationSlowMotionMultiplier (void) {
 	if (([NSEvent modifierFlags] & NSDeviceIndependentModifierFlagsMask) == NSShiftKeyMask) {
 		return 5.0;
 	} else {
@@ -155,13 +155,13 @@ static CGFloat SlomoTime() {
 }
 
 + (void)setAnimationDuration:(NSTimeInterval)duration {
-	duration *= SlomoTime();
+	duration *= TUIViewAnimationSlowMotionMultiplier();
 	TUIViewCurrentAnimation.basicAnimation.duration = duration;
 	[NSAnimationContext currentContext].duration = duration;
 }
 
 + (void)setAnimationDelay:(NSTimeInterval)delay {
-	TUIViewCurrentAnimation.basicAnimation.beginTime = CACurrentMediaTime() + delay * SlomoTime();
+	TUIViewCurrentAnimation.basicAnimation.beginTime = CACurrentMediaTime() + delay * TUIViewAnimationSlowMotionMultiplier();
 	TUIViewCurrentAnimation.basicAnimation.fillMode = kCAFillModeBoth;
 }
 

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -138,6 +138,10 @@ static CGFloat SlomoTime() {
 	[NSAnimationContext endGrouping];
 }
 
++ (BOOL)isDefiningAnimation {
+	return TUIViewCurrentAnimation != nil;
+}
+
 + (void)setAnimationDelegate:(id)delegate {
 	TUIViewCurrentAnimation.delegate = delegate;
 }

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -33,48 +33,49 @@
 
 @implementation TUIViewAnimation
 
-- (id)init
-{
-	if((self = [super init]))
-	{
-		basicAnimation = [CABasicAnimation animation];
-	}
+- (id)init {
+	self = [super init];
+	if (self == nil) return nil;
+
+	_basicAnimation = [CABasicAnimation animation];
 	return self;
 }
 
-- (void)dealloc
-{
-	if(animationCompletionBlock != nil) {
-		animationCompletionBlock(NO);
+- (void)dealloc {
+	if (self.animationCompletionBlock != nil) {
+		self.animationCompletionBlock(NO);
 		NSLog(@"Error: animation completion block didn't complete!");
 	}
 }
 
-- (void)runActionForKey:(NSString *)event object:(id)anObject arguments:(NSDictionary *)dict
-{
-	CAAnimation *animation = [basicAnimation copyWithZone:nil];
+- (void)runActionForKey:(NSString *)event object:(id)anObject arguments:(NSDictionary *)dict {
+	CAAnimation *animation = [self.basicAnimation copyWithZone:nil];
 	animation.delegate = self;
 	[animation runActionForKey:event object:anObject arguments:dict];
 }
 
-- (void)animationDidStart:(CAAnimation *)anim
-{
-	if(delegate && animationWillStartSelector) {
-		void (*animationWillStartIMP)(id,SEL,NSString*,void*) = (void(*)(id,SEL,NSString*,void*))[(NSObject *)delegate methodForSelector:animationWillStartSelector];
-		animationWillStartIMP(delegate, animationWillStartSelector, animationID, context);
-		animationWillStartSelector = NULL; // only fire this once
-	}
+- (void)animationDidStart:(CAAnimation *)anim {
+	if (self.delegate == nil || self.animationWillStartSelector == NULL) return;
+
+	void (*animationWillStartIMP)(id, SEL, NSString *, void *) = (__typeof__(animationWillStartIMP))[(id)self.delegate methodForSelector:self.animationWillStartSelector];
+	animationWillStartIMP(self.delegate, self.animationWillStartSelector, self.animationID, self.context);
+
+	// only fire this once
+	self.animationWillStartSelector = NULL;
 }
 
-- (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag
-{
-	if(delegate && animationDidStopSelector) {
-		void (*animationDidStopIMP)(id,SEL,NSString*,NSNumber*,void*) = (void(*)(id,SEL,NSString*,NSNumber*,void*))[(NSObject *)delegate methodForSelector:animationDidStopSelector];
-		animationDidStopIMP(delegate, animationDidStopSelector, animationID, [NSNumber numberWithBool:flag], context);
-		animationDidStopSelector = NULL; // only fire this once
-	} else if(animationCompletionBlock) {
-		animationCompletionBlock(flag);
-		self.animationCompletionBlock = nil; // only fire this once
+- (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag {
+	if (self.delegate != nil && self.animationDidStopSelector != NULL) {
+		void (*animationDidStopIMP)(id, SEL, NSString *, NSNumber *, void *) = (__typeof__(animationDidStopIMP))[(id)self.delegate methodForSelector:self.animationDidStopSelector];
+		animationDidStopIMP(self.delegate, self.animationDidStopSelector, self.animationID, @(flag), self.context);
+
+		// only fire this once
+		self.animationDidStopSelector = NULL;
+	} else if (self.animationCompletionBlock) {
+		self.animationCompletionBlock(flag);
+
+		// only fire this once
+		self.animationCompletionBlock = nil;
 	}
 }
 
@@ -84,34 +85,30 @@
 
 static NSMutableArray *AnimationStack = nil;
 
-+ (NSMutableArray *)_animationStack
-{
-	if(!AnimationStack)
-		AnimationStack = [[NSMutableArray alloc] init];
++ (NSMutableArray *)_animationStack {
+	if(!AnimationStack) AnimationStack = [[NSMutableArray alloc] init];
 	return AnimationStack;
 }
 
-+ (TUIViewAnimation *)_currentAnimation
-{
++ (TUIViewAnimation *)_currentAnimation {
 	return [AnimationStack lastObject];
 }
 
-+ (void)animateWithDuration:(NSTimeInterval)duration animations:(void (^)(void))animations
-{
++ (void)animateWithDuration:(NSTimeInterval)duration animations:(void (^)(void))animations {
 	[self animateWithDuration:duration animations:animations completion:NULL];
 }
 
-+ (void)animateWithDuration:(NSTimeInterval)duration animations:(void (^)(void))animations completion:(void (^)(BOOL finished))completion
-{
++ (void)animateWithDuration:(NSTimeInterval)duration animations:(void (^)(void))animations completion:(void (^)(BOOL finished))completion {
 	[self beginAnimations:nil context:NULL];
-	[self setAnimationDuration:duration];
-	[[self _currentAnimation] setAnimationCompletionBlock:completion];
+	self.animationDuration = duration;
+	[self _currentAnimation].animationCompletionBlock = completion;
+
 	animations();
+
 	[self commitAnimations];
 }
 
-+ (void)beginAnimations:(NSString *)animationID context:(void *)context
-{
++ (void)beginAnimations:(NSString *)animationID context:(void *)context {
 	[NSAnimationContext beginGrouping];
 
 	TUIViewAnimation *animation = [[TUIViewAnimation alloc] init];
@@ -120,60 +117,54 @@ static NSMutableArray *AnimationStack = nil;
 	[[self _animationStack] addObject:animation];
 	
 	// setup defaults
-	[self setAnimationDuration:0.25];
-	[self setAnimationCurve:TUIViewAnimationCurveEaseInOut];
+	self.animationDuration = 0.25;
+	self.animationCurve = TUIViewAnimationCurveEaseInOut;
 }
 
-+ (void)commitAnimations
-{
++ (void)commitAnimations {
 	[[self _animationStack] removeLastObject];
 	[NSAnimationContext endGrouping];
 }
 
-+ (void)setAnimationDelegate:(id)delegate
-{
++ (void)setAnimationDelegate:(id)delegate {
 	[self _currentAnimation].delegate = delegate;
 }
 
-+ (void)setAnimationWillStartSelector:(SEL)selector
-{
++ (void)setAnimationWillStartSelector:(SEL)selector {
 	[self _currentAnimation].animationWillStartSelector = selector;
 }
 
-+ (void)setAnimationDidStopSelector:(SEL)selector
-{
++ (void)setAnimationDidStopSelector:(SEL)selector {
 	[self _currentAnimation].animationDidStopSelector = selector;
 }
 
-static CGFloat SlomoTime()
-{
-	if((NSUInteger)([NSEvent modifierFlags]&NSDeviceIndependentModifierFlagsMask) == (NSUInteger)(NSShiftKeyMask))
+static CGFloat SlomoTime() {
+	if (([NSEvent modifierFlags] & NSDeviceIndependentModifierFlagsMask) == NSShiftKeyMask) {
 		return 5.0;
-	return 1.0;
+	} else {
+		return 1.0;
+	}
 }
 
-+ (void)setAnimationDuration:(NSTimeInterval)duration
-{
++ (void)setAnimationDuration:(NSTimeInterval)duration {
 	duration *= SlomoTime();
 	[self _currentAnimation].basicAnimation.duration = duration;
 	[NSAnimationContext currentContext].duration = duration;
 }
 
-+ (void)setAnimationDelay:(NSTimeInterval)delay
-{
++ (void)setAnimationDelay:(NSTimeInterval)delay {
 	[self _currentAnimation].basicAnimation.beginTime = CACurrentMediaTime() + delay * SlomoTime();
 	[self _currentAnimation].basicAnimation.fillMode = kCAFillModeBoth;
 }
 
-+ (void)setAnimationStartDate:(NSDate *)startDate
-{
++ (void)setAnimationStartDate:(NSDate *)startDate {
 	NSAssert(NO, @"%s is not yet implemented", __func__);
 }
 
-+ (void)setAnimationCurve:(TUIViewAnimationCurve)curve
-{
++ (void)setAnimationCurve:(TUIViewAnimationCurve)curve {
 	NSString *functionName = kCAMediaTimingFunctionEaseInEaseOut;
-	switch(curve) {
+
+	switch (curve) {
 		case TUIViewAnimationCurveLinear:
 			functionName = kCAMediaTimingFunctionLinear;
 			break;
@@ -186,91 +177,80 @@ static CGFloat SlomoTime()
 		case TUIViewAnimationCurveEaseInOut:
 			functionName = kCAMediaTimingFunctionEaseInEaseOut;
 			break;
+		default:
+			NSAssert(NO, @"Unrecognized animation curve: %i", (int)curve);
 	}
+
 	[self _currentAnimation].basicAnimation.timingFunction = [CAMediaTimingFunction functionWithName:functionName];
 }
 
-+ (void)setAnimationRepeatCount:(float)repeatCount
-{
++ (void)setAnimationRepeatCount:(float)repeatCount {
 	[self _currentAnimation].basicAnimation.repeatCount = repeatCount;
 }
 
-+ (void)setAnimationRepeatAutoreverses:(BOOL)repeatAutoreverses
-{
++ (void)setAnimationRepeatAutoreverses:(BOOL)repeatAutoreverses {
 	[self _currentAnimation].basicAnimation.autoreverses = repeatAutoreverses;
 }
 
-+ (void)setAnimationIsAdditive:(BOOL)additive
-{
++ (void)setAnimationIsAdditive:(BOOL)additive {
 	[self _currentAnimation].basicAnimation.additive = additive;
 }
 
-+ (void)setAnimationBeginsFromCurrentState:(BOOL)fromCurrentState
-{
++ (void)setAnimationBeginsFromCurrentState:(BOOL)fromCurrentState {
 	NSAssert(NO, @"%s is not yet implemented", __func__);
 }
 
-+ (void)setAnimationTransition:(TUIViewAnimationTransition)transition forView:(TUIView *)view cache:(BOOL)cache
-{
++ (void)setAnimationTransition:(TUIViewAnimationTransition)transition forView:(TUIView *)view cache:(BOOL)cache {
 	NSAssert(NO, @"%s is not yet implemented", __func__);
 }
 
 static BOOL disableAnimations = NO;
 
-+ (void)setAnimationsEnabled:(BOOL)enabled block:(void(^)(void))block
-{
++ (void)setAnimationsEnabled:(BOOL)enabled block:(void(^)(void))block {
 	BOOL save = disableAnimations;
 	disableAnimations = !enabled;
 	block();
 	disableAnimations = save;
 }
 
-+ (void)setAnimationsEnabled:(BOOL)enabled
-{
++ (void)setAnimationsEnabled:(BOOL)enabled {
 	disableAnimations = !enabled;
 }
 
-+ (BOOL)areAnimationsEnabled
-{
++ (BOOL)areAnimationsEnabled {
 	return !disableAnimations;
 }
 
 static BOOL animateContents = NO;
 
-+ (void)setAnimateContents:(BOOL)enabled
-{
++ (void)setAnimateContents:(BOOL)enabled {
 	animateContents = enabled;
 }
 
-+ (BOOL)willAnimateContents
-{
++ (BOOL)willAnimateContents {
 	return animateContents;
 }
 
-- (void)removeAllAnimations
-{
+- (void)removeAllAnimations {
 	[self.layer removeAllAnimations];
 	[self.subviews makeObjectsPerformSelector:@selector(removeAllAnimations)];
 }
 
-- (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event
-{
+- (id<CAAction>)actionForLayer:(CALayer *)layer forKey:(NSString *)event {
 	id defaultAction = [NSNull null];
+	if (disableAnimations) return defaultAction;
 
-	if(disableAnimations)
-		return defaultAction;
-
-	if((animateContents == NO) && [event isEqualToString:@"contents"])
-		return defaultAction; // default - don't animate contents
+	// default - don't animate contents
+	if (!animateContents && [event isEqualToString:@"contents"]) return defaultAction;
 
 	id animation = [TUIView _currentAnimation];
-	if (!animation)
-		return defaultAction;
+	if (animation == nil) return defaultAction;
 
-	if ([TUICAAction interceptsActionForKey:event])
+	if ([TUICAAction interceptsActionForKey:event]) {
 		return [TUICAAction actionWithAction:animation];
-	else
+	} else {
 		return animation;
+	}
 }
 
 @end

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -165,10 +165,6 @@ static CGFloat TUIViewAnimationSlowMotionMultiplier (void) {
 	TUIViewCurrentAnimation.basicAnimation.fillMode = kCAFillModeBoth;
 }
 
-+ (void)setAnimationStartDate:(NSDate *)startDate {
-	NSAssert(NO, @"%s is not yet implemented", __func__);
-}
-
 + (void)setAnimationCurve:(TUIViewAnimationCurve)curve {
 	NSString *functionName = kCAMediaTimingFunctionEaseInEaseOut;
 
@@ -202,14 +198,6 @@ static CGFloat TUIViewAnimationSlowMotionMultiplier (void) {
 
 + (void)setAnimationIsAdditive:(BOOL)additive {
 	TUIViewCurrentAnimation.basicAnimation.additive = additive;
-}
-
-+ (void)setAnimationBeginsFromCurrentState:(BOOL)fromCurrentState {
-	NSAssert(NO, @"%s is not yet implemented", __func__);
-}
-
-+ (void)setAnimationTransition:(TUIViewAnimationTransition)transition forView:(TUIView *)view cache:(BOOL)cache {
-	NSAssert(NO, @"%s is not yet implemented", __func__);
 }
 
 + (void)setAnimationsEnabled:(BOOL)enabled block:(void(^)(void))block {

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -188,7 +188,7 @@ static CGFloat SlomoTime()
 
 + (void)setAnimationStartDate:(NSDate *)startDate
 {
-	NSLog(@"%@ %@ unimplemented", self, NSStringFromSelector(_cmd));
+	NSAssert(NO, @"%s is not yet implemented", __func__);
 }
 
 + (void)setAnimationCurve:(TUIViewAnimationCurve)curve
@@ -228,12 +228,12 @@ static CGFloat SlomoTime()
 
 + (void)setAnimationBeginsFromCurrentState:(BOOL)fromCurrentState
 {
-	NSLog(@"%@ %@ unimplemented", self, NSStringFromSelector(_cmd));
+	NSAssert(NO, @"%s is not yet implemented", __func__);
 }
 
 + (void)setAnimationTransition:(TUIViewAnimationTransition)transition forView:(TUIView *)view cache:(BOOL)cache
 {
-	NSLog(@"%@ %@ unimplemented", self, NSStringFromSelector(_cmd));
+	NSAssert(NO, @"%s is not yet implemented", __func__);
 }
 
 static BOOL disableAnimations = NO;

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -138,7 +138,7 @@ static CGFloat SlomoTime() {
 	[NSAnimationContext endGrouping];
 }
 
-+ (BOOL)isDefiningAnimation {
++ (BOOL)isInAnimationContext {
 	return TUIViewCurrentAnimation != nil;
 }
 

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -63,10 +63,10 @@ static CGFloat TUIViewAnimationSlowMotionMultiplier (void) {
 }
 
 - (void)dealloc {
-	if (self.animationCompletionBlock != nil) {
-		self.animationCompletionBlock(NO);
-		NSLog(@"Error: animation completion block didn't complete!");
-	}
+	if (self.animationCompletionBlock == nil) return;
+
+	self.animationCompletionBlock(NO);
+	if (self.animationCompletionBlock != nil) NSLog(@"Error: animationCompletionBlock didn't complete!");
 }
 
 - (void)runActionForKey:(NSString *)event object:(id)anObject arguments:(NSDictionary *)dict {

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -70,7 +70,7 @@ static CGFloat TUIViewAnimationSlowMotionMultiplier (void) {
 }
 
 - (void)runActionForKey:(NSString *)event object:(id)anObject arguments:(NSDictionary *)dict {
-	CAAnimation *animation = [self.basicAnimation copyWithZone:nil];
+	CAAnimation *animation = [self.basicAnimation copy];
 	animation.delegate = self;
 	[animation runActionForKey:event object:anObject arguments:dict];
 }

--- a/lib/UIKit/TUIView+Animation.m
+++ b/lib/UIKit/TUIView+Animation.m
@@ -54,24 +54,20 @@
 
 @synthesize basicAnimation;
 
-//static int animcount = 0;
-
 - (id)init
 {
 	if((self = [super init]))
 	{
 		basicAnimation = [CABasicAnimation animation];
-//		NSLog(@"+anims %d", ++animcount);
 	}
 	return self;
 }
 
 - (void)dealloc
 {
-//	NSLog(@"-anims %d", --animcount);
 	if(animationCompletionBlock != nil) {
 		animationCompletionBlock(NO);
-		NSLog(@"Error: completion block didn't complete! %@", self);
+		NSLog(@"Error: animation completion block didn't complete!");
 	}
 }
 
@@ -82,11 +78,8 @@
 	[animation runActionForKey:event object:anObject arguments:dict];
 }
 
-//static int animstart = 0;
-
 - (void)animationDidStart:(CAAnimation *)anim
 {
-//	NSLog(@"+animstart %d", ++animstart);
 	if(delegate && animationWillStartSelector) {
 		void (*animationWillStartIMP)(id,SEL,NSString*,void*) = (void(*)(id,SEL,NSString*,void*))[(NSObject *)delegate methodForSelector:animationWillStartSelector];
 		animationWillStartIMP(delegate, animationWillStartSelector, animationID, context);
@@ -96,7 +89,6 @@
 
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag
 {
-//	NSLog(@"-animstart %d", --animstart);
 	if(delegate && animationDidStopSelector) {
 		void (*animationDidStopIMP)(id,SEL,NSString*,NSNumber*,void*) = (void(*)(id,SEL,NSString*,NSNumber*,void*))[(NSObject *)delegate methodForSelector:animationDidStopSelector];
 		animationDidStopIMP(delegate, animationDidStopSelector, animationID, [NSNumber numberWithBool:flag], context);
@@ -108,7 +100,6 @@
 }
 
 @end
-
 
 @implementation TUIView (TUIViewAnimation)
 
@@ -152,16 +143,12 @@ static NSMutableArray *AnimationStack = nil;
 	// setup defaults
 	[self setAnimationDuration:0.25];
 	[self setAnimationCurve:TUIViewAnimationCurveEaseInOut];
-	
-//	NSLog(@"+++ %d", [[self _animationStack] count]);
 }
 
 + (void)commitAnimations
 {
 	[[self _animationStack] removeLastObject];
 	[NSAnimationContext endGrouping];
-	
-//	NSLog(@"--- %d", [[self _animationStack] count]);
 }
 
 + (void)setAnimationDelegate:(id)delegate
@@ -169,12 +156,12 @@ static NSMutableArray *AnimationStack = nil;
 	[self _currentAnimation].delegate = delegate;
 }
 
-+ (void)setAnimationWillStartSelector:(SEL)selector                // default = NULL. -animationWillStart:(NSString *)animationID context:(void *)context
++ (void)setAnimationWillStartSelector:(SEL)selector
 {
 	[self _currentAnimation].animationWillStartSelector = selector;
 }
 
-+ (void)setAnimationDidStopSelector:(SEL)selector                  // default = NULL. -animationDidStop:(NSString *)animationID finished:(NSNumber *)finished context:(void *)context
++ (void)setAnimationDidStopSelector:(SEL)selector
 {
 	[self _currentAnimation].animationDidStopSelector = selector;
 }
@@ -193,19 +180,18 @@ static CGFloat SlomoTime()
 	[NSAnimationContext currentContext].duration = duration;
 }
 
-+ (void)setAnimationDelay:(NSTimeInterval)delay                    // default = 0.0
++ (void)setAnimationDelay:(NSTimeInterval)delay
 {
 	[self _currentAnimation].basicAnimation.beginTime = CACurrentMediaTime() + delay * SlomoTime();
 	[self _currentAnimation].basicAnimation.fillMode = kCAFillModeBoth;
 }
 
-+ (void)setAnimationStartDate:(NSDate *)startDate                  // default = now ([NSDate date])
++ (void)setAnimationStartDate:(NSDate *)startDate
 {
 	NSLog(@"%@ %@ unimplemented", self, NSStringFromSelector(_cmd));
-	//[self _currentAnimation].basicAnimation.beginTime = startDate;
 }
 
-+ (void)setAnimationCurve:(TUIViewAnimationCurve)curve              // default = UIViewAnimationCurveEaseInOut
++ (void)setAnimationCurve:(TUIViewAnimationCurve)curve
 {
 	NSString *functionName = kCAMediaTimingFunctionEaseInEaseOut;
 	switch(curve) {
@@ -225,12 +211,12 @@ static CGFloat SlomoTime()
 	[self _currentAnimation].basicAnimation.timingFunction = [CAMediaTimingFunction functionWithName:functionName];
 }
 
-+ (void)setAnimationRepeatCount:(float)repeatCount                 // default = 0.0.  May be fractional
++ (void)setAnimationRepeatCount:(float)repeatCount
 {
 	[self _currentAnimation].basicAnimation.repeatCount = repeatCount;
 }
 
-+ (void)setAnimationRepeatAutoreverses:(BOOL)repeatAutoreverses    // default = NO. used if repeat count is non-zero
++ (void)setAnimationRepeatAutoreverses:(BOOL)repeatAutoreverses
 {
 	[self _currentAnimation].basicAnimation.autoreverses = repeatAutoreverses;
 }
@@ -240,12 +226,12 @@ static CGFloat SlomoTime()
 	[self _currentAnimation].basicAnimation.additive = additive;
 }
 
-+ (void)setAnimationBeginsFromCurrentState:(BOOL)fromCurrentState  // default = NO. If YES, the current view position is always used for new animations -- allowing animations to "pile up" on each other. Otherwise, the last end state is used for the animation (the default).
++ (void)setAnimationBeginsFromCurrentState:(BOOL)fromCurrentState
 {
 	NSLog(@"%@ %@ unimplemented", self, NSStringFromSelector(_cmd));
 }
 
-+ (void)setAnimationTransition:(TUIViewAnimationTransition)transition forView:(TUIView *)view cache:(BOOL)cache  // current limitation - only one per begin/commit block
++ (void)setAnimationTransition:(TUIViewAnimationTransition)transition forView:(TUIView *)view cache:(BOOL)cache
 {
 	NSLog(@"%@ %@ unimplemented", self, NSStringFromSelector(_cmd));
 }
@@ -260,7 +246,7 @@ static BOOL disableAnimations = NO;
 	disableAnimations = save;
 }
 
-+ (void)setAnimationsEnabled:(BOOL)enabled                         // ignore any attribute changes while set.
++ (void)setAnimationsEnabled:(BOOL)enabled
 {
 	disableAnimations = !enabled;
 }

--- a/lib/UIKit/TUIView.h
+++ b/lib/UIKit/TUIView.h
@@ -435,14 +435,10 @@ extern CGRect(^TUIViewCenteredLayout)(TUIView*);
  */
 + (void)setAnimationDelay:(NSTimeInterval)delay;
 
-+ (void)setAnimationStartDate:(NSDate *)startDate;                  // default = now ([NSDate date])
 + (void)setAnimationCurve:(TUIViewAnimationCurve)curve;              // default = UIViewAnimationCurveEaseInOut
 + (void)setAnimationRepeatCount:(float)repeatCount;                 // default = 0.0.  May be fractional
 + (void)setAnimationRepeatAutoreverses:(BOOL)repeatAutoreverses;    // default = NO. used if repeat count is non-zero
-+ (void)setAnimationBeginsFromCurrentState:(BOOL)fromCurrentState;  // default = NO. If YES, the current view position is always used for new animations -- allowing animations to "pile up" on each other. Otherwise, the last end state is used for the animation (the default).
 + (void)setAnimationIsAdditive:(BOOL)additive;
-
-+ (void)setAnimationTransition:(TUIViewAnimationTransition)transition forView:(TUIView *)view cache:(BOOL)cache;  // current limitation - only one per begin/commit block
 
 + (void)setAnimationsEnabled:(BOOL)enabled block:(void(^)(void))block;
 + (void)setAnimationsEnabled:(BOOL)enabled;                         // ignore any attribute changes while set.

--- a/lib/UIKit/TUIView.h
+++ b/lib/UIKit/TUIView.h
@@ -449,6 +449,11 @@ extern CGRect(^TUIViewCenteredLayout)(TUIView*);
 + (BOOL)areAnimationsEnabled;
 
 /**
+ Whether the current code is being executed from within an animation (block-based or not).
+ */
++ (BOOL)isDefiningAnimation;
+
+/**
  animate the 'contents' property when set, defaults to NO
  */
 + (void)setAnimateContents:(BOOL)enabled;

--- a/lib/UIKit/TUIView.h
+++ b/lib/UIKit/TUIView.h
@@ -451,7 +451,7 @@ extern CGRect(^TUIViewCenteredLayout)(TUIView*);
 /**
  Whether the current code is being executed from within an animation (block-based or not).
  */
-+ (BOOL)isDefiningAnimation;
++ (BOOL)isInAnimationContext;
 
 /**
  animate the 'contents' property when set, defaults to NO


### PR DESCRIPTION
Besides making the code bearable, this also fixes a weird issue where `TUIViewAnimation` objects would get double-released (causing crashes), due to being autoreleased unnecessarily somewhere. Pulling out the current animation object into a static variable (instead of calling an `NSArray` method to grab it) seems to fix the problem.

Also added `+[TUIView isInAnimationContext]`, which can be used to determine whether animator proxies should be used in AppKit lulz. 
