### PR TITLE
TUITextView now responds to -editable property

### DIFF
--- a/lib/UIKit/TUITextEditor.h
+++ b/lib/UIKit/TUITextEditor.h
@@ -24,6 +24,8 @@
 	NSDictionary *defaultAttributes;
 	NSDictionary *markedAttributes;
 	BOOL wasValidKeyEquivalentSelector;
+    
+    BOOL editable;
 }
 
 - (NSTextInputContext *)inputContext;
@@ -38,6 +40,8 @@
 @property (nonatomic, strong) NSDictionary *markedAttributes;
 
 @property (nonatomic, assign) NSRange selectedRange;
+
+@property (nonatomic, assign, getter = isEditable) BOOL editable;
 
 - (void)insertText:(id)aString; // at cursor
 - (void)insertText:(id)aString replacementRange:(NSRange)replacementRange;

--- a/lib/UIKit/TUITextEditor.h
+++ b/lib/UIKit/TUITextEditor.h
@@ -24,8 +24,6 @@
 	NSDictionary *defaultAttributes;
 	NSDictionary *markedAttributes;
 	BOOL wasValidKeyEquivalentSelector;
-    
-    BOOL editable;
 }
 
 - (NSTextInputContext *)inputContext;
@@ -41,6 +39,12 @@
 
 @property (nonatomic, assign) NSRange selectedRange;
 
+/*
+ * If NO: ignore key down, copy, and paste events while preserving click and tap responses.
+ *
+ * @note Automatically assumes value of owning TUITextView's (if any) property of the same name.
+ * 
+ */
 @property (nonatomic, assign, getter = isEditable) BOOL editable;
 
 - (void)insertText:(id)aString; // at cursor

--- a/lib/UIKit/TUITextEditor.m
+++ b/lib/UIKit/TUITextEditor.m
@@ -23,7 +23,6 @@
 @synthesize defaultAttributes;
 @synthesize markedAttributes;
 @dynamic selectedRange; // getter in TUITextRenderer
-@synthesize editable;
 
 - (id)init
 {
@@ -101,8 +100,9 @@
 
 - (void)paste:(id)sender
 {
-    if (self.isEditable)
+    if (self.editable) {
         [self insertText:[[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString]];
+    }
 }
 
 - (void)patchMenuWithStandardEditingMenuItems:(NSMenu *)menu
@@ -117,8 +117,9 @@
 
 - (void)keyDown:(NSEvent *)event
 {
-    if (self.isEditable)
+    if (self.editable) {
         [inputContext handleEvent:event]; // transform into commands
+    }
 }
 
 - (void)mouseDown:(NSEvent *)event
@@ -147,9 +148,10 @@
 
 - (void)deleteCharactersInRange:(NSRange)range // designated delete
 {
-    //no point in reacting to the delegate key if we aren't editable
-    if (!self.isEditable)
+    //no point in reacting to the delete key if we aren't editable
+    if (!self.editable) {
         return;
+    }
 	if(range.length == 0)
 		return;
 	

--- a/lib/UIKit/TUITextEditor.m
+++ b/lib/UIKit/TUITextEditor.m
@@ -23,6 +23,7 @@
 @synthesize defaultAttributes;
 @synthesize markedAttributes;
 @dynamic selectedRange; // getter in TUITextRenderer
+@synthesize editable;
 
 - (id)init
 {
@@ -100,8 +101,8 @@
 
 - (void)paste:(id)sender
 {
-	[self insertText:[[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString]];
     if (self.isEditable)
+        [self insertText:[[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString]];
 }
 
 - (void)patchMenuWithStandardEditingMenuItems:(NSMenu *)menu
@@ -116,15 +117,16 @@
 
 - (void)keyDown:(NSEvent *)event
 {
-	[inputContext handleEvent:event]; // transform into commands
+    if (self.isEditable)
+        [inputContext handleEvent:event]; // transform into commands
 }
 
 - (void)mouseDown:(NSEvent *)event
 {
-	BOOL handled = [inputContext handleEvent:event];
-	if(handled) return;
-	
-	[super mouseDown:event];
+    BOOL handled = [inputContext handleEvent:event];
+    if(handled) return;
+    
+    [super mouseDown:event];
 }
 
 - (void)mouseDragged:(NSEvent *)event
@@ -145,7 +147,9 @@
 
 - (void)deleteCharactersInRange:(NSRange)range // designated delete
 {
+    //no point in reacting to the delegate key if we aren't editable
     if (!self.isEditable)
+        return;
 	if(range.length == 0)
 		return;
 	
@@ -190,7 +194,7 @@
 	// Some key equivalents--most notably command-arrows--should be handled and translated into selectors by our input context. But the input context will claim it consumed the event when it really just translated it into the `noop:` selector. So in that case, we want to go ahead and send the event up the responder chain.
 	BOOL consumed = [inputContext handleEvent:event];
 	if(consumed && wasValidKeyEquivalentSelector) return YES;
-
+    
 	return [super performKeyEquivalent:event];
 }
 
@@ -233,11 +237,11 @@
 	[self _textDidChange];
 }
 
-/* The receiver inserts aString replacing the content specified by replacementRange. 
- aString can be either an NSString or NSAttributedString instance. 
- selectedRange specifies the selection inside the string being inserted; 
- hence, the location is relative to the beginning of aString. 
- When aString is an NSString, the receiver is expected to render the marked 
+/* The receiver inserts aString replacing the content specified by replacementRange.
+ aString can be either an NSString or NSAttributedString instance.
+ selectedRange specifies the selection inside the string being inserted;
+ hence, the location is relative to the beginning of aString.
+ When aString is an NSString, the receiver is expected to render the marked
  text with distinguishing appearance (i.e. NSTextView renders with -markedTextAttributes).
  */
 - (void)setMarkedText:(id)aString selectedRange:(NSRange)newSelection replacementRange:(NSRange)replacementRange
@@ -275,12 +279,12 @@
 	[self _textDidChange];
 }
 
-/* The receiver unmarks the marked text. If no marked text, the invocation of this 
+/* The receiver unmarks the marked text. If no marked text, the invocation of this
  method has no effect.
  */
 - (void)unmarkText
 {
-//	NSLog(@"unmarkText");
+    //	NSLog(@"unmarkText");
 	markedRange = NSMakeRange(NSNotFound, 0);
     [inputContext discardMarkedText];
 }
@@ -307,9 +311,9 @@
 	return (markedRange.location != NSNotFound);
 }
 
-/* Returns attributed string specified by aRange. It may return nil. 
- If non-nil return value and actualRange is non-NULL, it contains the actual range 
- for the return value. The range can be adjusted from various reasons 
+/* Returns attributed string specified by aRange. It may return nil.
+ If non-nil return value and actualRange is non-NULL, it contains the actual range
+ for the return value. The range can be adjusted from various reasons
  (i.e. adjust to grapheme cluster boundary, performance optimization, etc).
  */
 - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
@@ -331,8 +335,8 @@
 	return [NSArray arrayWithObjects:NSMarkedClauseSegmentAttributeName, NSGlyphInfoAttributeName, nil];
 }
 
-/* Returns the first logical rectangular area for aRange. The return value is in the screen 
- coordinate. The size value can be negative if the text flows to the left. 
+/* Returns the first logical rectangular area for aRange. The return value is in the screen
+ coordinate. The size value can be negative if the text flows to the left.
  If non-NULL, actuallRange contains the character range corresponding to the returned area.
  */
 - (NSRect)firstRectForCharacterRange:(NSRange)aRange actualRange:(NSRangePointer)actualRange
@@ -350,7 +354,7 @@
     return screenRect;
 }
 
-/* Returns the index for character that is nearest to aPoint. aPoint is in the 
+/* Returns the index for character that is nearest to aPoint. aPoint is in the
  screen coordinate system.
  */
 - (NSUInteger)characterIndexForPoint:(NSPoint)screenPoint
@@ -366,9 +370,9 @@
 }
 
 #pragma mark optional
-/* Returns an attributed string representing the receiver's document content. 
- An NSTextInputClient can implement this interface if can be done efficiently. 
- The caller of this interface can random access arbitrary portions of the 
+/* Returns an attributed string representing the receiver's document content.
+ An NSTextInputClient can implement this interface if can be done efficiently.
+ The caller of this interface can random access arbitrary portions of the
  receiver's content more efficiently.
  */
 - (NSAttributedString *)attributedString
@@ -376,7 +380,7 @@
 	return backingStore;
 }
 
-/* Returns the fraction of distance for aPoint from the left side of the character. 
+/* Returns the fraction of distance for aPoint from the left side of the character.
  This allows caller to perform precise selection handling.
  */
 #if 1
@@ -386,8 +390,8 @@
 }
 #endif
 
-/* Returns the baseline position relative to the origin of rectangle returned 
- by -firstRectForCharacterRange:actualRange:. This information allows the caller 
+/* Returns the baseline position relative to the origin of rectangle returned
+ by -firstRectForCharacterRange:actualRange:. This information allows the caller
  to access finer-grained character position inside the NSTextInputClient document.
  */
 #if 1
@@ -397,7 +401,7 @@
 }
 #endif
 
-/* Returns the window level of the receiver. An NSTextInputClient can implement 
+/* Returns the window level of the receiver. An NSTextInputClient can implement
  this interface to specify its window level if it is higher than NSFloatingWindowLevel.
  */
 - (NSInteger)windowLevel

--- a/lib/UIKit/TUITextEditor.m
+++ b/lib/UIKit/TUITextEditor.m
@@ -101,6 +101,7 @@
 - (void)paste:(id)sender
 {
 	[self insertText:[[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString]];
+    if (self.isEditable)
 }
 
 - (void)patchMenuWithStandardEditingMenuItems:(NSMenu *)menu
@@ -144,6 +145,7 @@
 
 - (void)deleteCharactersInRange:(NSRange)range // designated delete
 {
+    if (!self.isEditable)
 	if(range.length == 0)
 		return;
 	

--- a/lib/UIKit/TUITextView.m
+++ b/lib/UIKit/TUITextView.m
@@ -98,14 +98,14 @@
 	if (self.textColor != nil) {
 		[attributes setObject:(__bridge id)self.textColor.tui_CGColor forKey:(__bridge id)kCTForegroundColorAttributeName];
 	}
-
+    
 	NSParagraphStyle *style = ABNSParagraphStyleForTextAlignment(textAlignment);
 	if (style != nil) {
 		[attributes setObject:style forKey:NSParagraphStyleAttributeName];
 	}
-
+    
 	[attributes setObject:self.font forKey:(__bridge id)kCTFontAttributeName];
-
+    
 	renderer.defaultAttributes = attributes;
 	renderer.markedAttributes = attributes;
 }
@@ -185,7 +185,7 @@
 {
 	textColor = c;
 	[self _updateDefaultAttributes];
-}	
+}
 
 - (void)setTextAlignment:(TUITextAlignment)t
 {
@@ -234,7 +234,7 @@ static CAAnimation *ThrobAnimation()
 	return b;
 }
 
-- (BOOL)_isKey // will fix
+- (BOOL)_isKey // will fix (but now responds to -editable).
 {
 	NSResponder *firstResponder = [self.nsWindow firstResponder];
 	if(firstResponder == self) {
@@ -243,7 +243,6 @@ static CAAnimation *ThrobAnimation()
 		[self.nsWindow tui_makeFirstResponder:renderer];
 		firstResponder = renderer;
 	}
-	return (firstResponder == renderer);
 	return (firstResponder == renderer  && self.editable);
 }
 
@@ -352,7 +351,7 @@ static CAAnimation *ThrobAnimation()
 		// restore
 		renderer.attributedString = [renderer backingStore];
 	}
-		
+    
 	return r;
 }
 
@@ -406,7 +405,7 @@ static CAAnimation *ThrobAnimation()
 					unichar lastCharacter = [[[renderer backingStore] string] characterAtIndex:self.selectedRange.location - 1];
 					if(lastCharacter == '\'') continue;
 				}
-								
+                
 				if(result.resultType == NSTextCheckingTypeCorrection || result.resultType == NSTextCheckingTypeReplacement) {
 					NSString *backingString = [[renderer backingStore] string];
 					if(NSMaxRange(result.range) <= backingString.length) {
@@ -439,7 +438,7 @@ static CAAnimation *ThrobAnimation()
 			
 			[[renderer backingStore] endEditing];
 			[renderer reset]; // make sure we reset so that the renderer uses our new attributes
-
+            
 			[self setNeedsDisplay];
 			
 			self.lastCheckResults = results;
@@ -470,7 +469,7 @@ static CAAnimation *ThrobAnimation()
 	}
 	
 	if(selectedTextCheckingResult == nil) return nil;
-		
+    
 	NSMenu *menu = [[NSMenu alloc] initWithTitle:@""];
 	if(selectedTextCheckingResult.resultType == NSTextCheckingTypeCorrection && matchingAutocorrectPair != nil) {
 		NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Change Back to \"%@\"", @""), matchingAutocorrectPair.originalString] action:@selector(_replaceAutocorrectedWord:) keyEquivalent:@""];
@@ -603,6 +602,7 @@ static CAAnimation *ThrobAnimation()
 - (BOOL)acceptsFirstResponder
 {
     if (!self.editable)
+        return NO;
     return YES;
 }
 
@@ -620,7 +620,7 @@ static CAAnimation *ThrobAnimation()
 		BOOL consumed = [delegate textView:self doCommandBySelector:selector];
 		if(consumed) return YES;
 	}
-		
+    
 	if(selector == @selector(moveUp:)) {
 		if([self singleLine]) {
 			self.selectedRange = NSMakeRange(0, 0);

--- a/lib/UIKit/TUITextView.m
+++ b/lib/UIKit/TUITextView.m
@@ -198,6 +198,11 @@
 	return [[self text] length] > 0;
 }
 
+-(void)setEditable:(BOOL)editable_ {
+    [renderer setEditable:editable_];
+    editable = editable_;
+}
+
 static CAAnimation *ThrobAnimation()
 {
 	CAKeyframeAnimation *a = [CAKeyframeAnimation animation];

--- a/lib/UIKit/TUITextView.m
+++ b/lib/UIKit/TUITextView.m
@@ -601,9 +601,7 @@ static CAAnimation *ThrobAnimation()
 
 - (BOOL)acceptsFirstResponder
 {
-    if (!self.editable)
-        return NO;
-    return YES;
+    return self.editable;
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent *)event {

--- a/lib/UIKit/TUITextView.m
+++ b/lib/UIKit/TUITextView.m
@@ -244,6 +244,7 @@ static CAAnimation *ThrobAnimation()
 		firstResponder = renderer;
 	}
 	return (firstResponder == renderer);
+	return (firstResponder == renderer  && self.editable);
 }
 
 - (void)drawRect:(CGRect)rect
@@ -601,6 +602,7 @@ static CAAnimation *ThrobAnimation()
 
 - (BOOL)acceptsFirstResponder
 {
+    if (!self.editable)
     return YES;
 }
 

--- a/lib/UIKit/TUIViewNSViewContainer.m
+++ b/lib/UIKit/TUIViewNSViewContainer.m
@@ -166,7 +166,7 @@
 	CGContextSaveGState(context);
 	CGContextClearRect(context, self.bounds);
 
-	if ([self.rootView isFlipped]) {
+	if (![self.rootView isFlipped]) {
 		CGContextTranslateCTM(context, 0, self.bounds.size.height);
 		CGContextScaleCTM(context, 1, -1);
 	}


### PR DESCRIPTION
`TUITextView` would not respond to its `editable` property before, and it had much to do with the event handling architecture of the renderer.  If one wanted an un-editable text view, one would have to set `-userInteractionEnabled` to FALSE, which disabled the dictionary and any attempts at copying and pasting.  I've added two new exposed properties to the `TUITextView` and `TUITextEditor` classes that enable this functionality by checking the property before any key, copy, or cut events are accepted.  Mouse down events remain unchanged, however.  `TUITextView` automatically syncs its `editable` property to that of its renderer.
