### PR TITLE
Conditionalize flippedness for < 10.8 and 10.8+

### DIFF
--- a/lib/UIKit/TUIViewNSViewContainer.m
+++ b/lib/UIKit/TUIViewNSViewContainer.m
@@ -168,6 +168,7 @@
 
 	NSLog(@"rootView isFlipped: %i", (int)[self.rootView isFlipped]);
 	NSLog(@"context isFlipped: %i", (int)[[NSGraphicsContext currentContext] isFlipped]);
+	NSLog(@"layer flipped: %i", (int)self.layer.geometryFlipped);
 
 	if ([self.rootView isFlipped]) {
 		CGContextTranslateCTM(context, 0, self.bounds.size.height);

--- a/lib/UIKit/TUIViewNSViewContainer.m
+++ b/lib/UIKit/TUIViewNSViewContainer.m
@@ -23,6 +23,7 @@
 #import "TUINSView.h"
 #import "TUINSView+Private.h"
 #import "TUIViewNSViewContainer+Private.h"
+#import <CoreServices/CoreServices.h>
 
 @interface TUIViewNSViewContainer () {
 	/**
@@ -166,11 +167,15 @@
 	CGContextSaveGState(context);
 	CGContextClearRect(context, self.bounds);
 
-	NSLog(@"rootView isFlipped: %i", (int)[self.rootView isFlipped]);
-	NSLog(@"context isFlipped: %i", (int)[[NSGraphicsContext currentContext] isFlipped]);
-	NSLog(@"layer flipped: %i", (int)self.layer.geometryFlipped);
+	SInt32 major, minor;
+	Gestalt(gestaltSystemVersionMajor, &major);
+	Gestalt(gestaltSystemVersionMinor, &minor);
 
-	if ([self.rootView isFlipped]) {
+	// 10.8 seems to have changed whether -renderInContext: renders the NSView
+	// flipped or not.
+	BOOL needsToFlip = (major > 10 || (major == 10 && minor == 8)) ? [self.rootView isFlipped] : ![self.rootView isFlipped];
+
+	if (needsToFlip) {
 		CGContextTranslateCTM(context, 0, self.bounds.size.height);
 		CGContextScaleCTM(context, 1, -1);
 	}

--- a/lib/UIKit/TUIViewNSViewContainer.m
+++ b/lib/UIKit/TUIViewNSViewContainer.m
@@ -173,7 +173,7 @@
 
 	// 10.8 seems to have changed whether -renderInContext: renders the NSView
 	// flipped or not.
-	BOOL needsToFlip = (major > 10 || (major == 10 && minor == 8)) ? [self.rootView isFlipped] : ![self.rootView isFlipped];
+	BOOL needsToFlip = (major > 10 || (major == 10 && minor >= 8)) ? [self.rootView isFlipped] : ![self.rootView isFlipped];
 
 	if (needsToFlip) {
 		CGContextTranslateCTM(context, 0, self.bounds.size.height);

--- a/lib/UIKit/TUIViewNSViewContainer.m
+++ b/lib/UIKit/TUIViewNSViewContainer.m
@@ -166,6 +166,9 @@
 	CGContextSaveGState(context);
 	CGContextClearRect(context, self.bounds);
 
+	NSLog(@"rootView isFlipped: %i", (int)[self.rootView isFlipped]);
+	NSLog(@"context isFlipped: %i", (int)[[NSGraphicsContext currentContext] isFlipped]);
+
 	if ([self.rootView isFlipped]) {
 		CGContextTranslateCTM(context, 0, self.bounds.size.height);
 		CGContextScaleCTM(context, 1, -1);


### PR DESCRIPTION
#49 redux. #37 redux redux.

Apparently, the behavior of invoking `renderInContext:` on the layer of a layer-backed `NSView` silently changed in 10.8. `isFlipped` on the view, the graphics context, and the layer all return the same values across the different OS versions, so doing a system version check seemed to be the only way to really fix this.

Tested on 10.7.4 and 10.8.1.
