### PR TITLE
TUITextView should be editable by default

### DIFF
--- a/lib/UIKit/TUITextView.m
+++ b/lib/UIKit/TUITextView.m
@@ -136,6 +136,8 @@
 		[self _updateDefaultAttributes];
 		
 		self.drawFrame = TUITextViewStandardFrame();
+
+		self.editable = YES;
 	}
 	return self;
 }


### PR DESCRIPTION
This bug was introduced as part of the work in #62.

`editable` should default to `YES`.
