### PR TITLE
More consistent TUTableView scrolling behavior with maintainContentOffsetAfterReload

### DIFF
--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -658,10 +658,16 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 		CGFloat previousOffset = 0.0f;
 		NSIndexPath *savedIndexPath = nil;
 		CGFloat relativeOffset = 0.0;
+		
+		CGFloat resizingOffset = 0.0;
+		if ([self.nsView inLiveResize]) {
+			resizingOffset = (_lastSize.height - bounds.size.height);
+		}
+		
 		if(_tableFlags.maintainContentOffsetAfterReload) {
 			previousOffset = self.contentSize.height + self.contentOffset.y;
 		} else {
-			if(_tableFlags.forceSaveScrollPosition || [self.nsView inLiveResize]) {
+			if(_tableFlags.forceSaveScrollPosition || resizingOffset) {
 				_tableFlags.forceSaveScrollPosition = 0;
 				NSArray *a = [INDEX_PATHS_FOR_VISIBLE_ROWS sortedArrayUsingSelector:@selector(compare:)];
 				if([a count]) {
@@ -669,7 +675,7 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 					CGRect v = [self visibleRect];
 					CGRect r = [self rectForRowAtIndexPath:savedIndexPath];
 					relativeOffset = ((v.origin.y + v.size.height) - (r.origin.y + r.size.height));
-					relativeOffset += (_lastSize.height - bounds.size.height);
+					relativeOffset += resizingOffset;
 				}
 			} else if(_keepVisibleIndexPathForReload) {
 				savedIndexPath = _keepVisibleIndexPathForReload;
@@ -690,7 +696,7 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 		
 		// restore scroll position
 		if(_tableFlags.maintainContentOffsetAfterReload) {
-			CGFloat newOffset = previousOffset - self.contentSize.height;
+			CGFloat newOffset = previousOffset - self.contentSize.height - resizingOffset;
 			self.contentOffset = CGPointMake(self.contentOffset.x, newOffset);
 		} else {
 			if(savedIndexPath) {


### PR DESCRIPTION
Taking into account the view resizing during the preLayout even when
the maintainContentOffsetAfterReload is set, to produce a consistent
scrolling behavior.

I don't know if you prefer to check again if the view is resizing, or you're 
ok with checking if the float has been set, just let me know.

Should fix issue #59
