### PR TITLE
Fixes for TUIAccessibilityElement

### DIFF
--- a/TwUI.xcodeproj/project.pbxproj
+++ b/TwUI.xcodeproj/project.pbxproj
@@ -127,6 +127,12 @@
 		88EFFB5413F417E200CF91A9 /* TUITextViewEditor.m in Sources */ = {isa = PBXBuildFile; fileRef = 88EFFB5013F417E200CF91A9 /* TUITextViewEditor.m */; };
 		88EFFB5513F417E200CF91A9 /* TUITextViewEditor.m in Sources */ = {isa = PBXBuildFile; fileRef = 88EFFB5013F417E200CF91A9 /* TUITextViewEditor.m */; };
 		88EFFB5613F417E200CF91A9 /* TUITextViewEditor.m in Sources */ = {isa = PBXBuildFile; fileRef = 88EFFB5013F417E200CF91A9 /* TUITextViewEditor.m */; };
+		A3F4E31B160530D0006FDAFD /* TUIAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = A3F4E319160530D0006FDAFD /* TUIAccessibilityElement.h */; };
+		A3F4E31C160530D0006FDAFD /* TUIAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = A3F4E319160530D0006FDAFD /* TUIAccessibilityElement.h */; };
+		A3F4E31D160530D0006FDAFD /* TUIAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = A3F4E319160530D0006FDAFD /* TUIAccessibilityElement.h */; };
+		A3F4E31E160530D0006FDAFD /* TUIAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = A3F4E31A160530D0006FDAFD /* TUIAccessibilityElement.m */; };
+		A3F4E31F160530D0006FDAFD /* TUIAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = A3F4E31A160530D0006FDAFD /* TUIAccessibilityElement.m */; };
+		A3F4E320160530D0006FDAFD /* TUIAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = A3F4E31A160530D0006FDAFD /* TUIAccessibilityElement.m */; };
 		CB5B265A13BE6DA200579B1E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CB5B265813BE6DA200579B1E /* InfoPlist.strings */; };
 		CB5B266313BE6DA300579B1E /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB5B266213BE6DA300579B1E /* SenTestingKit.framework */; };
 		CB5B266413BE6DA300579B1E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB5B264F13BE6DA200579B1E /* Cocoa.framework */; };
@@ -460,6 +466,8 @@
 		88D81CFE1577EF0D009D453B /* TUIStyledView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TUIStyledView.m; sourceTree = "<group>"; };
 		88EFFB4F13F417E200CF91A9 /* TUITextViewEditor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TUITextViewEditor.h; sourceTree = "<group>"; };
 		88EFFB5013F417E200CF91A9 /* TUITextViewEditor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TUITextViewEditor.m; sourceTree = "<group>"; };
+		A3F4E319160530D0006FDAFD /* TUIAccessibilityElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TUIAccessibilityElement.h; sourceTree = "<group>"; };
+		A3F4E31A160530D0006FDAFD /* TUIAccessibilityElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TUIAccessibilityElement.m; sourceTree = "<group>"; };
 		CB5B264C13BE6DA200579B1E /* TwUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TwUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CB5B264F13BE6DA200579B1E /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		CB5B265213BE6DA200579B1E /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -752,6 +760,8 @@
 		CBB74C3D13BE6E1900C85CB5 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				A3F4E319160530D0006FDAFD /* TUIAccessibilityElement.h */,
+				A3F4E31A160530D0006FDAFD /* TUIAccessibilityElement.m */,
 				D0C7655915B6297200E7AC2C /* NSClipView+TUIExtensions.h */,
 				D0C7655A15B6297200E7AC2C /* NSClipView+TUIExtensions.m */,
 				D0EA12EF15C34FEA00FAA603 /* NSColor+TUIExtensions.h */,
@@ -935,6 +945,7 @@
 				D05DEE8E15BF645D005D8769 /* TUIStretchableImage.h in Headers */,
 				D05D23A215BF7239000ED14F /* NSImage+TUIExtensions.h in Headers */,
 				D0EA12F315C34FEA00FAA603 /* NSColor+TUIExtensions.h in Headers */,
+				A3F4E31D160530D0006FDAFD /* TUIAccessibilityElement.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1007,6 +1018,7 @@
 				D05DEE8C15BF645D005D8769 /* TUIStretchableImage.h in Headers */,
 				D05D23A015BF7239000ED14F /* NSImage+TUIExtensions.h in Headers */,
 				D0EA12F115C34FEA00FAA603 /* NSColor+TUIExtensions.h in Headers */,
+				A3F4E31B160530D0006FDAFD /* TUIAccessibilityElement.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1040,6 +1052,7 @@
 				D05DEE8D15BF645D005D8769 /* TUIStretchableImage.h in Headers */,
 				D05D23A115BF7239000ED14F /* NSImage+TUIExtensions.h in Headers */,
 				D0EA12F215C34FEA00FAA603 /* NSColor+TUIExtensions.h in Headers */,
+				A3F4E31C160530D0006FDAFD /* TUIAccessibilityElement.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1321,6 +1334,7 @@
 				D05DEE9115BF645D005D8769 /* TUIStretchableImage.m in Sources */,
 				D05D23A515BF7239000ED14F /* NSImage+TUIExtensions.m in Sources */,
 				D0EA12F615C34FEA00FAA603 /* NSColor+TUIExtensions.m in Sources */,
+				A3F4E320160530D0006FDAFD /* TUIAccessibilityElement.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1397,6 +1411,7 @@
 				D05D23A315BF7239000ED14F /* NSImage+TUIExtensions.m in Sources */,
 				887C227C15C1C7BB006EC31D /* NSFont+TUIExtensions.m in Sources */,
 				D0EA12F415C34FEA00FAA603 /* NSColor+TUIExtensions.m in Sources */,
+				A3F4E31E160530D0006FDAFD /* TUIAccessibilityElement.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1478,6 +1493,7 @@
 				D05DEE9015BF645D005D8769 /* TUIStretchableImage.m in Sources */,
 				D05D23A415BF7239000ED14F /* NSImage+TUIExtensions.m in Sources */,
 				D0EA12F515C34FEA00FAA603 /* NSColor+TUIExtensions.m in Sources */,
+				A3F4E31F160530D0006FDAFD /* TUIAccessibilityElement.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/UIKit/TUIAccessibilityElement.h
+++ b/lib/UIKit/TUIAccessibilityElement.h
@@ -15,7 +15,7 @@
 	NSString *accessibilityLabel;
 }
 
-@property (nonatomic, __unsafe_unretained) id accessibilityContainer;
+@property (nonatomic, unsafe_unretained) id accessibilityContainer;
 @property (nonatomic, copy) NSString *accessibilityLabel;
 
 @end


### PR DESCRIPTION
Somehow TUIAccessibilityElement was removed or never added to the Xcode project. Secondarily there was a syntax issue with a property. Both of these issues are fixed.

I only noticed this when updating the CocoaPods spec file as each version excludes this file to avoid a compiler error.
