### PR TITLE
Fix nine part image drawing

### DIFF
--- a/lib/UIKit/TUIStretchableImage.m
+++ b/lib/UIKit/TUIStretchableImage.m
@@ -135,7 +135,7 @@
 	}
 
 	if (topLeft != nil || bottomRight != nil) {
-		NSDrawNinePartImage(dstRect, topLeft, topEdge, topRight, leftEdge, center, rightEdge, bottomLeft, bottomEdge, bottomRight, op, alpha, flipped);
+		NSDrawNinePartImage(dstRect, bottomLeft, bottomEdge, bottomRight, leftEdge, center, rightEdge, topLeft, topEdge, topRight, op, alpha, flipped);
 	} else if (leftEdge != nil) {
 		// Horizontal three-part image.
 		NSDrawThreePartImage(dstRect, leftEdge, center, rightEdge, NO, op, alpha, flipped);


### PR DESCRIPTION
I have an image named `dark_window_bg.png`:
![](http://f.cl.ly/items/2O1V3A2K3l2X0P2A3R3r/dark_window_bg.png)

And I drew the image using the following code in a TUIView's `drawRect:` method:

``` objective-c
NSImage *imageBg = [[NSImage imageNamed:@"dark_window_bg"] tui_resizableImageWithCapInsets:TUIEdgeInsetsMake(32, 17, 32, 17)];
[imageBg tui_drawInRect:self.bounds];
```

I was expecting something like:
![](http://f.cl.ly/items/291k151W4433163T471T/%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202012-09-25%20%E4%B8%8A%E5%8D%887.54.32.png)

But what I saw on screen is an upside down image.
![](http://f.cl.ly/items/1B0f280A1D3X1J23463e/%E5%B1%8F%E5%B9%95%E5%BF%AB%E7%85%A7%202012-09-25%20%E4%B8%8A%E5%8D%888.04.49.png)

Clearly it worked when I swapped the 'top' images with the 'bottom' images. Although I'm not sure if it's the right way to fix it.
