### PR TITLE
Correcting sizing issue when drawing button's with text edge insets and

### DIFF
--- a/lib/UIKit/TUIButton.m
+++ b/lib/UIKit/TUIButton.m
@@ -236,7 +236,7 @@ static CGRect ButtonRectCenteredInRect(CGRect a, CGRect b)
 		CGContextSetAlpha(ctx, 0.5);
 	CGRect titleFrame = self.bounds;
 	titleFrame.size.width -= (_titleEdgeInsets.left + _titleEdgeInsets.right);
-    titleFrame.size.height -= (_titleEdgeInsets.top + _titleEdgeInsets.bottom);
+	titleFrame.size.height -= (_titleEdgeInsets.top + _titleEdgeInsets.bottom);
 	self.titleLabel.frame = titleFrame;
 	[self.titleLabel drawRect:self.titleLabel.bounds];
 	CGContextRestoreGState(ctx);

--- a/lib/UIKit/TUIButton.m
+++ b/lib/UIKit/TUIButton.m
@@ -236,6 +236,7 @@ static CGRect ButtonRectCenteredInRect(CGRect a, CGRect b)
 		CGContextSetAlpha(ctx, 0.5);
 	CGRect titleFrame = self.bounds;
 	titleFrame.size.width -= (_titleEdgeInsets.left + _titleEdgeInsets.right);
+    titleFrame.size.height -= (_titleEdgeInsets.top + _titleEdgeInsets.bottom);
 	self.titleLabel.frame = titleFrame;
 	[self.titleLabel drawRect:self.titleLabel.bounds];
 	CGContextRestoreGState(ctx);

--- a/lib/UIKit/TUILabel.m
+++ b/lib/UIKit/TUILabel.m
@@ -40,7 +40,7 @@
 {
 	if((self = [super initWithFrame:frame])) {
 		renderer = [[TUITextRenderer alloc] init];
-        renderer.verticalAlignment = TUITextVerticalAlignmentMiddle;
+		renderer.verticalAlignment = TUITextVerticalAlignmentMiddle;
 		[self setTextRenderers:[NSArray arrayWithObjects:renderer, nil]];
 		
 		_lineBreakMode = TUILineBreakModeClip;

--- a/lib/UIKit/TUILabel.m
+++ b/lib/UIKit/TUILabel.m
@@ -40,6 +40,7 @@
 {
 	if((self = [super initWithFrame:frame])) {
 		renderer = [[TUITextRenderer alloc] init];
+        renderer.verticalAlignment = TUITextVerticalAlignmentMiddle;
 		[self setTextRenderers:[NSArray arrayWithObjects:renderer, nil]];
 		
 		_lineBreakMode = TUILineBreakModeClip;


### PR DESCRIPTION
...defaulting button title rendering to be vertically aligned. (This is the standard default for OS X and iOS)
