### PR TITLE
Revert "Take acceptsFirstResponder into account."

### DIFF
--- a/lib/UIKit/TUINSWindow.m
+++ b/lib/UIKit/TUINSWindow.m
@@ -67,8 +67,6 @@ NSInteger makeFirstResponderCount = 0;
 
 - (BOOL)tui_makeFirstResponder:(NSResponder *)aResponder
 {
-	if(![aResponder acceptsFirstResponder])
-		return NO;
 	++makeFirstResponderCount; // cool if it overflows
 	if([aResponder respondsToSelector:@selector(initialFirstResponder)])
 		aResponder = ((TUIResponder *)aResponder).initialFirstResponder;


### PR DESCRIPTION
`tui_makeFirstResponder:` should not check `acceptsFirstResponder`. This matches the behavior of `-[NSWindow makeFirstResponder:]`.

This reverts commit c636424772341201126bc8bea6f70f4f67b36962.

CC @galaxas0
