### PR TITLE
TUINavigationController

### DIFF
--- a/TwUI.xcodeproj/project.pbxproj
+++ b/TwUI.xcodeproj/project.pbxproj
@@ -61,6 +61,12 @@
 		5EE983EA13BE7834005F430D /* TUIViewNSViewContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB74C9013BE6E1900C85CB5 /* TUIViewNSViewContainer.m */; };
 		5EE983EB13BE783A005F430D /* ABActiveRange.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB74C3A13BE6E1900C85CB5 /* ABActiveRange.m */; };
 		5EE983EC13BE783A005F430D /* CoreText+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = CBB74C3C13BE6E1900C85CB5 /* CoreText+Additions.m */; };
+		84D6B5A81621181C00CD366D /* TUINavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 84D6B5A61621181C00CD366D /* TUINavigationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		84D6B5A91621181C00CD366D /* TUINavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 84D6B5A61621181C00CD366D /* TUINavigationController.h */; };
+		84D6B5AA1621181C00CD366D /* TUINavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 84D6B5A61621181C00CD366D /* TUINavigationController.h */; };
+		84D6B5AB1621181C00CD366D /* TUINavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 84D6B5A71621181C00CD366D /* TUINavigationController.m */; };
+		84D6B5AC1621181C00CD366D /* TUINavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 84D6B5A71621181C00CD366D /* TUINavigationController.m */; };
+		84D6B5AD1621181C00CD366D /* TUINavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 84D6B5A71621181C00CD366D /* TUINavigationController.m */; };
 		8819794413E26E0200AA39EB /* TUIView+Accessibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 8819794213E26E0200AA39EB /* TUIView+Accessibility.h */; };
 		8819794513E26E0200AA39EB /* TUIView+Accessibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 8819794213E26E0200AA39EB /* TUIView+Accessibility.h */; };
 		8819794613E26E0200AA39EB /* TUIView+Accessibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 8819794213E26E0200AA39EB /* TUIView+Accessibility.h */; };
@@ -429,6 +435,8 @@
 		48A10E8A15B77A46007F9EE3 /* TUIView+Layout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TUIView+Layout.h"; sourceTree = "<group>"; };
 		5EE9839C13BE7650005F430D /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
 		5EE983B713BE7809005F430D /* libtwui.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libtwui.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		84D6B5A61621181C00CD366D /* TUINavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TUINavigationController.h; sourceTree = "<group>"; };
+		84D6B5A71621181C00CD366D /* TUINavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TUINavigationController.m; sourceTree = "<group>"; };
 		8819794213E26E0200AA39EB /* TUIView+Accessibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TUIView+Accessibility.h"; sourceTree = "<group>"; };
 		8819794313E26E0200AA39EB /* TUIView+Accessibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TUIView+Accessibility.m"; sourceTree = "<group>"; };
 		8819794A13E26E5800AA39EB /* TUINSView+Accessibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TUINSView+Accessibility.h"; sourceTree = "<group>"; };
@@ -785,6 +793,8 @@
 				48A10E7E15B7769A007F9EE3 /* TUILayoutConstraint.m */,
 				48A10E7F15B7769A007F9EE3 /* TUILayoutManager.h */,
 				48A10E8015B7769A007F9EE3 /* TUILayoutManager.m */,
+				84D6B5A61621181C00CD366D /* TUINavigationController.h */,
+				84D6B5A71621181C00CD366D /* TUINavigationController.m */,
 				8819794A13E26E5800AA39EB /* TUINSView+Accessibility.h */,
 				8819794B13E26E5800AA39EB /* TUINSView+Accessibility.m */,
 				CBB74C5E13BE6E1900C85CB5 /* TUINSView+Hyperfocus.h */,
@@ -833,8 +843,8 @@
 				CBB74C7913BE6E1900C85CB5 /* TUITextRenderer+Event.h */,
 				CBB74C7A13BE6E1900C85CB5 /* TUITextRenderer+Event.m */,
 				CBB74C7B13BE6E1900C85CB5 /* TUITextRenderer+KeyBindings.m */,
-				CBB74C7C13BE6E1900C85CB5 /* TUITextRenderer.h */,
 				48373DF4160EAE9400322CA7 /* TUITextRenderer+Private.h */,
+				CBB74C7C13BE6E1900C85CB5 /* TUITextRenderer.h */,
 				CBB74C7D13BE6E1900C85CB5 /* TUITextRenderer.m */,
 				CBB74C7E13BE6E1900C85CB5 /* TUITextView.h */,
 				CBB74C7F13BE6E1900C85CB5 /* TUITextView.m */,
@@ -922,6 +932,7 @@
 				D05D23A215BF7239000ED14F /* NSImage+TUIExtensions.h in Headers */,
 				D0EA12F315C34FEA00FAA603 /* NSColor+TUIExtensions.h in Headers */,
 				48373DF7160EAE9400322CA7 /* TUITextRenderer+Private.h in Headers */,
+				84D6B5AA1621181C00CD366D /* TUINavigationController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -929,6 +940,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84D6B5A81621181C00CD366D /* TUINavigationController.h in Headers */,
 				CBB74C9113BE6E1900C85CB5 /* ABActiveRange.h in Headers */,
 				CBB74C9313BE6E1900C85CB5 /* CoreText+Additions.h in Headers */,
 				CBB74C9513BE6E1900C85CB5 /* TUIAccessibility.h in Headers */,
@@ -1027,6 +1039,7 @@
 				D05D23A115BF7239000ED14F /* NSImage+TUIExtensions.h in Headers */,
 				D0EA12F215C34FEA00FAA603 /* NSColor+TUIExtensions.h in Headers */,
 				48373DF6160EAE9400322CA7 /* TUITextRenderer+Private.h in Headers */,
+				84D6B5A91621181C00CD366D /* TUINavigationController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1306,6 +1319,7 @@
 				D05DEE9115BF645D005D8769 /* TUIStretchableImage.m in Sources */,
 				D05D23A515BF7239000ED14F /* NSImage+TUIExtensions.m in Sources */,
 				D0EA12F615C34FEA00FAA603 /* NSColor+TUIExtensions.m in Sources */,
+				84D6B5AD1621181C00CD366D /* TUINavigationController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1379,6 +1393,7 @@
 				D05D23A315BF7239000ED14F /* NSImage+TUIExtensions.m in Sources */,
 				887C227C15C1C7BB006EC31D /* NSFont+TUIExtensions.m in Sources */,
 				D0EA12F415C34FEA00FAA603 /* NSColor+TUIExtensions.m in Sources */,
+				84D6B5AB1621181C00CD366D /* TUINavigationController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1458,6 +1473,7 @@
 				D05DEE9015BF645D005D8769 /* TUIStretchableImage.m in Sources */,
 				D05D23A415BF7239000ED14F /* NSImage+TUIExtensions.m in Sources */,
 				D0EA12F515C34FEA00FAA603 /* NSColor+TUIExtensions.m in Sources */,
+				84D6B5AC1621181C00CD366D /* TUINavigationController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/UIKit/TUIKit.h
+++ b/lib/UIKit/TUIKit.h
@@ -33,6 +33,7 @@
 #import "TUIImageView.h"
 #import "TUILabel.h"
 #import "TUILayoutConstraint.h"
+#import "TUINavigationController.h"
 #import "TUINSView.h"
 #import "TUINSView+Hyperfocus.h"
 #import "TUINSView+NSTextInputClient.h"
@@ -57,3 +58,6 @@
 #import "TUIViewController.h"
 #import "TUIViewNSViewContainer.h"
 #import "NSFont+TUIExtensions.h"
+
+
+extern BOOL AtLeastLion; // set at launch

--- a/lib/UIKit/TUINavigationController.h
+++ b/lib/UIKit/TUINavigationController.h
@@ -1,0 +1,59 @@
+//
+//  TUINavigationController.h
+//  TUINavigationController
+//
+//  Created by Robert Widmann on 10/6/12.
+//  Copyright (c) 2012 CodaFi. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+#import "TUIViewController.h"
+#import "TUIGeometry.h"
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+/*!
+ TUINavigationController manages a stack of view controllers.
+ It performs horizontal view transitions for pushed and popped views.
+ This class aims to act as much like UINavigationController as much as possible,
+ so it's source will borrow heavily from Chameleon's UINavigationController implementation.
+ For more information about Chameleon, see https://github.com/BigZaphod/Chameleon/
+ */
+
+@protocol TUINavigationControllerDelegate;
+
+@interface TUINavigationController : TUIViewController
+
+- (id)initWithRootViewController:(TUIViewController *)rootViewController; // Convenience method pushes the root view controller without animation.
+
+- (void)pushViewController:(TUIViewController *)viewController animated:(BOOL)animated; // Uses a horizontal slide transition. Has no effect if the view controller is already in the stack.
+
+- (TUIViewController *)popViewControllerAnimated:(BOOL)animated; // Returns the popped controller.
+- (NSArray *)popToViewController:(TUIViewController *)viewController animated:(BOOL)animated; // Pops view controllers until the one specified is on top. Returns the popped controllers.
+- (NSArray *)popToRootViewControllerAnimated:(BOOL)animated; // Pops until there's only a single view controller left on the stack. Returns the popped controllers.
+
+@property(nonatomic,readonly,retain) TUIViewController *topViewController; // The top view controller on the stack.
+@property(nonatomic,readonly,retain) TUIViewController *visibleViewController; // Return modal view controller if it exists. Otherwise the top view controller.
+
+@property (nonatomic,strong) NSMutableArray *viewControllers; // The current view controller stack.
+- (void)setViewControllers:(NSArray *)viewControllers animated:(BOOL)animated; // If animated is YES, then simulate a push or pop depending on whether the new top view controller was previously in the stack.
+
+@property(nonatomic, assign) id<TUINavigationControllerDelegate> delegate;
+
+@end
+
+@protocol TUINavigationControllerDelegate <NSObject>
+
+@optional
+
+// Called when the navigation controller shows a new top view controller via a push, pop or setting of the view controller stack.
+- (void)navigationController:(TUINavigationController *)navigationController willShowViewController:(TUIViewController *)viewController animated:(BOOL)animated;
+- (void)navigationController:(TUINavigationController *)navigationController didShowViewController:(TUIViewController *)viewController animated:(BOOL)animated;
+
+@end
+
+@interface TUIViewController (TUINavigationControllerItem)
+
+@property(nonatomic,readonly,retain) TUINavigationController *navigationController; // If this view controller has been pushed onto a navigation controller, return it.
+
+@end

--- a/lib/UIKit/TUINavigationController.h
+++ b/lib/UIKit/TUINavigationController.h
@@ -13,12 +13,14 @@
 #import <CoreGraphics/CoreGraphics.h>
 
 /*!
- TUINavigationController manages a stack of view controllers.
- It performs horizontal view transitions for pushed and popped views.
- This class aims to act as much like UINavigationController as much as possible,
- so it's source will borrow heavily from Chameleon's UINavigationController implementation.
- For more information about Chameleon, see https://github.com/BigZaphod/Chameleon/
+ TUINavigationController manages a stack of view controllers and a navigation bar.
+ It performs horizontal view transitions for pushed and popped views while keeping the navigation bar in sync.
  */
+
+//Custom animation block for TUINavigationController's -pushViewController:withAnimationBlock;
+//Animates all methods called within it for the default duration of a push animation, then cleans up after itself
+//Do not call view removal methods on any of the block's parameters, they will be performed for you at the end of animation
+typedef void (^TUINavigationAnimationBlock)(TUIViewController *pushingFrom, TUIViewController *pushingTo, CGRect suggestedFrame);
 
 @protocol TUINavigationControllerDelegate;
 
@@ -27,6 +29,8 @@
 - (id)initWithRootViewController:(TUIViewController *)rootViewController; // Convenience method pushes the root view controller without animation.
 
 - (void)pushViewController:(TUIViewController *)viewController animated:(BOOL)animated; // Uses a horizontal slide transition. Has no effect if the view controller is already in the stack.
+
+- (void)pushViewController:(TUIViewController *)viewController withAnimationBlock:(TUINavigationAnimationBlock)block; // Uses a pre-defined block transition. Has no effect if the view controller is already in the stack.
 
 - (TUIViewController *)popViewControllerAnimated:(BOOL)animated; // Returns the popped controller.
 - (NSArray *)popToViewController:(TUIViewController *)viewController animated:(BOOL)animated; // Pops view controllers until the one specified is on top. Returns the popped controllers.

--- a/lib/UIKit/TUINavigationController.h
+++ b/lib/UIKit/TUINavigationController.h
@@ -13,36 +13,36 @@
 #import <CoreGraphics/CoreGraphics.h>
 
 /*!
- TUINavigationController manages a stack of view controllers and a navigation bar.
- It performs horizontal view transitions for pushed and popped views while keeping the navigation bar in sync.
+   TUINavigationController manages a stack of view controllers and a navigation bar.
+   It performs horizontal view transitions for pushed and popped views while keeping the navigation bar in sync.
  */
 
 //Custom animation block for TUINavigationController's -pushViewController:withAnimationBlock;
 //Animates all methods called within it for the default duration of a push animation, then cleans up after itself
 //Do not call view removal methods on any of the block's parameters, they will be performed for you at the end of animation
-typedef void (^TUINavigationAnimationBlock)(TUIViewController *pushingFrom, TUIViewController *pushingTo, CGRect suggestedFrame);
+typedef void ( ^TUINavigationAnimationBlock)(TUIViewController * pushingFrom, TUIViewController * pushingTo, CGRect suggestedFrame);
 
 @protocol TUINavigationControllerDelegate;
 
 @interface TUINavigationController : TUIViewController
 
-- (id)initWithRootViewController:(TUIViewController *)rootViewController; // Convenience method pushes the root view controller without animation.
+- (id) initWithRootViewController:(TUIViewController *)rootViewController; // Convenience method pushes the root view controller without animation.
 
-- (void)pushViewController:(TUIViewController *)viewController animated:(BOOL)animated; // Uses a horizontal slide transition. Has no effect if the view controller is already in the stack.
+- (void) pushViewController:(TUIViewController *)viewController animated:(BOOL)animated; // Uses a horizontal slide transition. Has no effect if the view controller is already in the stack.
 
-- (void)pushViewController:(TUIViewController *)viewController withAnimationBlock:(TUINavigationAnimationBlock)block; // Uses a pre-defined block transition. Has no effect if the view controller is already in the stack.
+- (void) pushViewController:(TUIViewController *)viewController withAnimationBlock:(TUINavigationAnimationBlock)block; // Uses a pre-defined block transition. Has no effect if the view controller is already in the stack.
 
-- (TUIViewController *)popViewControllerAnimated:(BOOL)animated; // Returns the popped controller.
-- (NSArray *)popToViewController:(TUIViewController *)viewController animated:(BOOL)animated; // Pops view controllers until the one specified is on top. Returns the popped controllers.
-- (NSArray *)popToRootViewControllerAnimated:(BOOL)animated; // Pops until there's only a single view controller left on the stack. Returns the popped controllers.
+- (TUIViewController *) popViewControllerAnimated:(BOOL)animated; // Returns the popped controller.
+- (NSArray *)           popToViewController:(TUIViewController *)viewController animated:(BOOL)animated; // Pops view controllers until the one specified is on top. Returns the popped controllers.
+- (NSArray *)           popToRootViewControllerAnimated:(BOOL)animated; // Pops until there's only a single view controller left on the stack. Returns the popped controllers.
 
-@property(nonatomic,readonly,retain) TUIViewController *topViewController; // The top view controller on the stack.
-@property(nonatomic,readonly,retain) TUIViewController *visibleViewController; // Return modal view controller if it exists. Otherwise the top view controller.
+@property (nonatomic, readonly, retain) TUIViewController *topViewController; // The top view controller on the stack.
+@property (nonatomic, readonly, retain) TUIViewController *visibleViewController; // Return modal view controller if it exists. Otherwise the top view controller.
 
-@property (nonatomic,strong) NSMutableArray *viewControllers; // The current view controller stack.
-- (void)setViewControllers:(NSArray *)viewControllers animated:(BOOL)animated; // If animated is YES, then simulate a push or pop depending on whether the new top view controller was previously in the stack.
+@property (nonatomic, strong) NSMutableArray *viewControllers; // The current view controller stack.
+- (void) setViewControllers:(NSArray *)viewControllers animated:(BOOL)animated; // If animated is YES, then simulate a push or pop depending on whether the new top view controller was previously in the stack.
 
-@property(nonatomic, assign) id<TUINavigationControllerDelegate> delegate;
+@property (nonatomic, assign) id <TUINavigationControllerDelegate> delegate;
 
 @end
 
@@ -51,13 +51,13 @@ typedef void (^TUINavigationAnimationBlock)(TUIViewController *pushingFrom, TUIV
 @optional
 
 // Called when the navigation controller shows a new top view controller via a push, pop or setting of the view controller stack.
-- (void)navigationController:(TUINavigationController *)navigationController willShowViewController:(TUIViewController *)viewController animated:(BOOL)animated;
-- (void)navigationController:(TUINavigationController *)navigationController didShowViewController:(TUIViewController *)viewController animated:(BOOL)animated;
+- (void) navigationController:(TUINavigationController *)navigationController willShowViewController:(TUIViewController *)viewController animated:(BOOL)animated;
+- (void) navigationController:(TUINavigationController *)navigationController didShowViewController:(TUIViewController *)viewController animated:(BOOL)animated;
 
 @end
 
 @interface TUIViewController (TUINavigationControllerItem)
 
-@property(nonatomic,readonly,retain) TUINavigationController *navigationController; // If this view controller has been pushed onto a navigation controller, return it.
+@property (nonatomic, readonly, retain) TUINavigationController *navigationController; // If this view controller has been pushed onto a navigation controller, return it.
 
 @end

--- a/lib/UIKit/TUINavigationController.m
+++ b/lib/UIKit/TUINavigationController.m
@@ -1,0 +1,290 @@
+//
+//  TUINavigationController.m
+//  TUINavigationController
+//
+//  Created by Robert Widmann on 10/6/12.
+//  Copyright (c) 2012 CodaFi. All rights reserved.
+//
+
+#import "TUINavigationController.h"
+#import <TwUI/TUIKit.h>
+
+typedef enum {
+	_TUINavigationControllerVisibleControllerTransitionNone = 0,
+	_TUINavigationControllerVisibleControllerTransitionPushAnimated,
+	_TUINavigationControllerVisibleControllerTransitionPopAnimated
+} _TUINavigationControllerVisibleControllerTransition;
+
+static const NSTimeInterval kAnimationDuration = 0.5;
+
+@interface TUINavigationController () {
+	_TUINavigationControllerVisibleControllerTransition _visibleViewControllerTransition;
+}
+@property(nonatomic,retain) TUIViewController *topViewController; // The top view controller on the stack.
+@property(nonatomic,retain) TUIViewController *visibleViewController; // Return modal view controller if it exists. Otherwise the top view controller.
+
+@property (nonatomic,assign) BOOL visibleViewControllerNeedsUpdate;
+@end
+
+@implementation TUINavigationController
+
+- (id)initWithRootViewController:(TUIViewController *)rootViewController {
+	if ((self=[super init])) {
+        self.viewControllers = [NSMutableArray arrayWithObject:rootViewController];
+		[rootViewController setParentViewController:self];
+		[self setVisibleViewController:rootViewController];
+    }
+    return self;
+}
+
+- (void)loadView
+{
+    self.view = [[TUIView alloc] initWithFrame:CGRectMake(0,0,320,480)];
+	[self.view setDrawRect:^(TUIView *v, CGRect rect) {
+		[[NSColor clearColor]set];
+		NSRectFill(rect);
+	}];
+	[self.view setAutoresizingMask:TUIViewAutoresizingFlexibleSize];
+    
+    TUIViewController *viewController = self.visibleViewController;
+    viewController.view.frame = [self _controllerFrameForTransition:_TUINavigationControllerVisibleControllerTransitionNone];
+    viewController.view.autoresizingMask = TUIViewAutoresizingFlexibleSize;
+	
+    [self.view addSubview:viewController.view];
+}
+
+-(TUIViewController*)topViewController {
+	return [self.viewControllers lastObject];
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    [self.visibleViewController viewWillAppear:animated];
+}
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [self.visibleViewController viewDidAppear:animated];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    [self.visibleViewController viewWillDisappear:animated];
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [super viewDidDisappear:animated];
+    [self.visibleViewController viewDidDisappear:animated];
+}
+
+- (CGRect)_controllerFrameForTransition:(_TUINavigationControllerVisibleControllerTransition)transition
+{
+    CGRect controllerFrame = self.view.bounds;
+    
+    if (transition == _TUINavigationControllerVisibleControllerTransitionPushAnimated) {
+        controllerFrame = CGRectOffset(controllerFrame, controllerFrame.size.width, 0);
+    } else if (transition == _TUINavigationControllerVisibleControllerTransitionPopAnimated) {
+        controllerFrame = CGRectOffset(controllerFrame, -controllerFrame.size.width, 0);
+    }
+    
+    return controllerFrame;
+}
+
+- (void)pushViewController:(TUIViewController *)viewController animated:(BOOL)animated
+{
+	//no duplicate view controllers allowed.
+    assert(![_viewControllers containsObject:viewController]);
+	
+	if (viewController == nil) {
+		NSLog(@"Application attempted to push nil view controller onto target %@", self);
+		return;
+	}
+	
+    // override the animated property based on current state
+    animated = animated && _visibleViewController;
+    
+	[viewController.view setAutoresizingMask:TUIViewAutoresizingFlexibleSize];
+
+    // push on to controllers stack
+    [_viewControllers addObject:viewController];
+    
+    // take ownership responsibility
+    [viewController setParentViewController:self];
+    
+	// if animated and on screen, begin part of the transition immediately, specifically, get the new view
+    // on screen asap and tell the new controller it's about to be made visible in an animated fashion
+	if (animated) {
+		_visibleViewControllerTransition = _TUINavigationControllerVisibleControllerTransitionPushAnimated;
+		
+		viewController.view.frame = [self _controllerFrameForTransition:_visibleViewControllerTransition];
+        
+		[_visibleViewController viewWillDisappear:YES];
+		[viewController viewWillAppear:YES];
+        
+        if ([_delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
+            [_delegate navigationController:self willShowViewController:viewController animated:YES];
+        }
+		
+		[self.view insertSubview:viewController.view atIndex:0];
+	}
+    
+	[self _setVisibleViewControllerNeedsUpdate];
+}
+
+- (TUIViewController *)popViewControllerAnimated:(BOOL)animated
+{
+    // don't allow popping the rootViewController
+    if ([_viewControllers count] <= 1) {
+        return nil;
+    }
+    
+    TUIViewController *formerTopViewController = self.topViewController;
+	
+	
+	// pop the controller stack
+    [_viewControllers removeLastObject];
+    
+    // give up ownership of the view controller
+    [formerTopViewController setParentViewController:nil];
+    
+	// if animated, begin part of the transition immediately, specifically, get the new top view on screen asap
+	// and tell the old visible controller it's about to be disappeared in an animated fashion
+	if (animated) {
+        // note the new top here so we don't have to use the accessor method all the time
+        TUIViewController *topController = self.topViewController;
+		
+		_visibleViewControllerTransition = _TUINavigationControllerVisibleControllerTransitionPopAnimated;
+		
+		// if we never updated the visible controller, we need to add the formerTopViewController
+		// on to the screen so we can see it disappear since we're attempting to animate this
+		if (!_visibleViewController) {
+			_visibleViewController = formerTopViewController;
+			_visibleViewController.view.frame = [self _controllerFrameForTransition:_TUINavigationControllerVisibleControllerTransitionNone];
+			[self.view insertSubview:_visibleViewController.view atIndex:0];
+		}
+        
+		topController.view.frame = [self _controllerFrameForTransition:_visibleViewControllerTransition];
+        
+		[_visibleViewController viewWillDisappear:YES];
+		[topController viewWillAppear:YES];
+		
+        if ([_delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
+            [_delegate navigationController:self willShowViewController:topController animated:YES];
+        }
+		
+		[self.view insertSubview:topController.view atIndex:0];
+		
+	}
+    
+	[self _setVisibleViewControllerNeedsUpdate];
+	
+	return formerTopViewController;
+}
+
+- (NSArray *)popToViewController:(TUIViewController *)viewController animated:(BOOL)animated
+{
+    NSMutableArray *popped = [[NSMutableArray alloc] init];
+	
+    if ([_viewControllers containsObject:viewController]) {
+        while (self.topViewController != viewController) {
+            TUIViewController *poppedController = [self popViewControllerAnimated:animated];
+            if (poppedController) {
+                [popped addObject:poppedController];
+            } else {
+                break;
+            }
+        }
+    }
+    
+    return [popped copy];
+}
+
+- (NSArray *)popToRootViewControllerAnimated:(BOOL)animated
+{
+    return [self popToViewController:[_viewControllers objectAtIndex:0] animated:animated];
+}
+
+- (void)setViewControllers:(NSArray *)newViewControllers animated:(BOOL)animated {
+	assert([newViewControllers count] >= 1);
+	
+    if (![newViewControllers isEqualToArray:_viewControllers]) {
+        // remove them all in bulk
+        [_viewControllers makeObjectsPerformSelector:@selector(_setParentViewController:) withObject:nil];
+        [_viewControllers removeAllObjects];
+        
+        // add them back in one-by-one and only apply animation to the last one (if any)
+        for (TUIViewController *controller in newViewControllers) {
+            [self pushViewController:controller animated:(animated && (controller == [newViewControllers lastObject]))];
+        }
+    }
+}
+
+- (void)_setVisibleViewControllerNeedsUpdate
+{
+	// schedules a deferred method to run
+	if (!_visibleViewControllerNeedsUpdate) {
+		_visibleViewControllerNeedsUpdate = YES;
+		[self performSelector:@selector(_updateVisibleViewController) withObject:nil afterDelay:0];
+	}
+}
+
+- (void)_updateVisibleViewController
+{
+	// do some bookkeeping
+	_visibleViewControllerNeedsUpdate = NO;
+    TUIViewController *topViewController = self.topViewController;
+    
+	// make sure the new top view is both loaded and set to appear in the correct place
+	topViewController.view.frame = [self _controllerFrameForTransition:_visibleViewControllerTransition];
+    
+	if (_visibleViewControllerTransition == _TUINavigationControllerVisibleControllerTransitionNone) {
+		[_visibleViewController viewWillDisappear:NO];
+		[topViewController viewWillAppear:NO];
+        
+        if ([_delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
+            [_delegate navigationController:self willShowViewController:topViewController animated:NO];
+        }
+        
+		[_visibleViewController.view removeFromSuperview];
+		[self.view insertSubview:topViewController.view atIndex:0];
+        
+		[_visibleViewController viewDidDisappear:NO];
+		[topViewController viewDidAppear:NO];
+		
+        if ([_delegate respondsToSelector:@selector(navigationController:didShowViewController:animated:)]) {
+            [_delegate navigationController:self didShowViewController:topViewController animated:NO];
+        }
+    } else {
+        const CGRect visibleControllerFrame = (_visibleViewControllerTransition == _TUINavigationControllerVisibleControllerTransitionPushAnimated)
+		? [self _controllerFrameForTransition:_TUINavigationControllerVisibleControllerTransitionPopAnimated]
+		: [self _controllerFrameForTransition:_TUINavigationControllerVisibleControllerTransitionPushAnimated];
+		
+        const CGRect topControllerFrame = [self _controllerFrameForTransition:_TUINavigationControllerVisibleControllerTransitionNone];
+        
+        TUIViewController *previouslyVisibleViewController = _visibleViewController;
+        
+        [TUIView animateWithDuration:kAnimationDuration
+                         animations:^(void) {
+                             previouslyVisibleViewController.view.frame = visibleControllerFrame;
+                             topViewController.view.frame = topControllerFrame;
+                         }
+                         completion:^(BOOL finished) {
+                             [previouslyVisibleViewController.view removeFromSuperview];
+                             [previouslyVisibleViewController viewDidDisappear:YES];
+                             [topViewController viewDidAppear:YES];
+                             
+                             if ([_delegate respondsToSelector:@selector(navigationController:didShowViewController:animated:)]) {
+                                 [_delegate navigationController:self didShowViewController:topViewController animated:YES];
+                             }
+                         }];
+	}
+    
+	_visibleViewController = topViewController;
+    
+}
+
+@end

--- a/lib/UIKit/TUINavigationController.m
+++ b/lib/UIKit/TUINavigationController.m
@@ -30,27 +30,27 @@ static const NSTimeInterval kAnimationDuration = 0.5;
 
 - (id)initWithRootViewController:(TUIViewController *)rootViewController {
 	if ((self=[super init])) {
-        self.viewControllers = [NSMutableArray arrayWithObject:rootViewController];
+		self.viewControllers = [NSMutableArray arrayWithObject:rootViewController];
 		[rootViewController setParentViewController:self];
 		[self setVisibleViewController:rootViewController];
-    }
-    return self;
+	}
+	return self;
 }
 
 - (void)loadView
 {
-    self.view = [[TUIView alloc] initWithFrame:CGRectMake(0,0,320,480)];
+	self.view = [[TUIView alloc] initWithFrame:CGRectMake(0,0,320,480)];
 	[self.view setDrawRect:^(TUIView *v, CGRect rect) {
 		[[NSColor clearColor]set];
 		NSRectFill(rect);
 	}];
 	[self.view setAutoresizingMask:TUIViewAutoresizingFlexibleSize];
-    
-    TUIViewController *viewController = self.visibleViewController;
-    viewController.view.frame = [self _controllerFrameForTransition:_TUINavigationControllerVisibleControllerTransitionNone];
-    viewController.view.autoresizingMask = TUIViewAutoresizingFlexibleSize;
 	
-    [self.view addSubview:viewController.view];
+	TUIViewController *viewController = self.visibleViewController;
+	viewController.view.frame = [self _controllerFrameForTransition:_TUINavigationControllerVisibleControllerTransitionNone];
+	viewController.view.autoresizingMask = TUIViewAutoresizingFlexibleSize;
+	
+	[self.view addSubview:viewController.view];
 }
 
 -(TUIViewController*)topViewController {
@@ -59,89 +59,89 @@ static const NSTimeInterval kAnimationDuration = 0.5;
 
 - (void)viewWillAppear:(BOOL)animated
 {
-    [super viewWillAppear:animated];
-    [self.visibleViewController viewWillAppear:animated];
+	[super viewWillAppear:animated];
+	[self.visibleViewController viewWillAppear:animated];
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
-    [super viewDidAppear:animated];
-    [self.visibleViewController viewDidAppear:animated];
+	[super viewDidAppear:animated];
+	[self.visibleViewController viewDidAppear:animated];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
 {
-    [super viewWillDisappear:animated];
-    [self.visibleViewController viewWillDisappear:animated];
+	[super viewWillDisappear:animated];
+	[self.visibleViewController viewWillDisappear:animated];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
-    [super viewDidDisappear:animated];
-    [self.visibleViewController viewDidDisappear:animated];
+	[super viewDidDisappear:animated];
+	[self.visibleViewController viewDidDisappear:animated];
 }
 
 - (CGRect)_controllerFrameForTransition:(_TUINavigationControllerVisibleControllerTransition)transition
 {
-    CGRect controllerFrame = self.view.bounds;
-    
-    if (transition == _TUINavigationControllerVisibleControllerTransitionPushAnimated) {
-        controllerFrame = CGRectOffset(controllerFrame, controllerFrame.size.width, 0);
-    } else if (transition == _TUINavigationControllerVisibleControllerTransitionPopAnimated) {
-        controllerFrame = CGRectOffset(controllerFrame, -controllerFrame.size.width, 0);
-    }
-    
-    return controllerFrame;
+	CGRect controllerFrame = self.view.bounds;
+	
+	if (transition == _TUINavigationControllerVisibleControllerTransitionPushAnimated) {
+		controllerFrame = CGRectOffset(controllerFrame, controllerFrame.size.width, 0);
+	} else if (transition == _TUINavigationControllerVisibleControllerTransitionPopAnimated) {
+		controllerFrame = CGRectOffset(controllerFrame, -controllerFrame.size.width, 0);
+	}
+	
+	return controllerFrame;
 }
 
 - (void)pushViewController:(TUIViewController *)viewController animated:(BOOL)animated
 {
-    assert(![_viewControllers containsObject:viewController]);
+	assert(![_viewControllers containsObject:viewController]);
 	
-    // override the animated property based on current state
-    animated = animated && _visibleViewController;
-    
+	// override the animated property based on current state
+	animated = animated && _visibleViewController;
+	
 	[viewController.view setAutoresizingMask:TUIViewAutoresizingFlexibleSize];
 	
-    // push on to controllers stack
-    [_viewControllers addObject:viewController];
-    
-    // take ownership responsibility
-    [viewController setParentViewController:self];
-    
+	// push on to controllers stack
+	[_viewControllers addObject:viewController];
+	
+	// take ownership responsibility
+	[viewController setParentViewController:self];
+	
 	// if animated and on screen, begin part of the transition immediately, specifically, get the new view
-    // on screen asap and tell the new controller it's about to be made visible in an animated fashion
+	// on screen asap and tell the new controller it's about to be made visible in an animated fashion
 	if (animated) {
 		_visibleViewControllerTransition = _TUINavigationControllerVisibleControllerTransitionPushAnimated;
 		
 		viewController.view.frame = [self _controllerFrameForTransition:_visibleViewControllerTransition];
-        
+		
 		[_visibleViewController viewWillDisappear:YES];
 		[viewController viewWillAppear:YES];
-        
-        if ([_delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
-            [_delegate navigationController:self willShowViewController:viewController animated:YES];
-        }
+		
+		if ([_delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
+			[_delegate navigationController:self willShowViewController:viewController animated:YES];
+		}
 		
 		[self.view insertSubview:viewController.view atIndex:0];
 	}
-    
+	
 	[self _setVisibleViewControllerNeedsUpdate];
 }
 
 - (void)pushViewController:(TUIViewController *)viewController withAnimationBlock:(TUINavigationAnimationBlock)block {
 	assert(![_viewControllers containsObject:viewController]);
-    
+	
 	[viewController.view setAutoresizingMask:TUIViewAutoresizingFlexibleSize];
 	
-    // push on to controllers stack
-    [_viewControllers addObject:viewController];
-    
-    // take ownership responsibility
-    [viewController setParentViewController:self];
-    
+	// push on to controllers stack
+	[_viewControllers addObject:viewController];
+	
+	// take ownership responsibility
+	[viewController setParentViewController:self];
+	
 	// if animated and on screen, begin part of the transition immediately, specifically, get the new view
-    // on screen asap and tell the new controller it's about to be made visible in an animated fashion
+	// on screen asap and tell the new controller it's about to be made visible in an animated fashion
 	_visibleViewControllerTransition = _TUINavigationControllerVisibleControllerTransitionPushAnimated;
 	
 	viewController.view.frame = [self _controllerFrameForTransition:_visibleViewControllerTransition];
@@ -154,31 +154,31 @@ static const NSTimeInterval kAnimationDuration = 0.5;
 	}
 	
 	[self.view insertSubview:viewController.view atIndex:0];
-    
+	
 	[self _setVisibleViewControllerNeedsUpdateWithBlock:block];
 }
 
 - (TUIViewController *)popViewControllerAnimated:(BOOL)animated
 {
-    // don't allow popping the rootViewController
-    if ([_viewControllers count] <= 1) {
-        return nil;
-    }
-    
-    TUIViewController *formerTopViewController = self.topViewController;
+	// don't allow popping the rootViewController
+	if ([_viewControllers count] <= 1) {
+		return nil;
+	}
+	
+	TUIViewController *formerTopViewController = self.topViewController;
 	
 	
 	// pop the controller stack
-    [_viewControllers removeLastObject];
-    
-    // give up ownership of the view controller
-    [formerTopViewController setParentViewController:nil];
-    
+	[_viewControllers removeLastObject];
+	
+	// give up ownership of the view controller
+	[formerTopViewController setParentViewController:nil];
+	
 	// if animated, begin part of the transition immediately, specifically, get the new top view on screen asap
 	// and tell the old visible controller it's about to be disappeared in an animated fashion
 	if (animated) {
-        // note the new top here so we don't have to use the accessor method all the time
-        TUIViewController *topController = self.topViewController;
+		// note the new top here so we don't have to use the accessor method all the time
+		TUIViewController *topController = self.topViewController;
 		
 		_visibleViewControllerTransition = _TUINavigationControllerVisibleControllerTransitionPopAnimated;
 		
@@ -189,20 +189,20 @@ static const NSTimeInterval kAnimationDuration = 0.5;
 			_visibleViewController.view.frame = [self _controllerFrameForTransition:_TUINavigationControllerVisibleControllerTransitionNone];
 			[self.view insertSubview:_visibleViewController.view atIndex:0];
 		}
-        
+		
 		topController.view.frame = [self _controllerFrameForTransition:_visibleViewControllerTransition];
-        
+		
 		[_visibleViewController viewWillDisappear:YES];
 		[topController viewWillAppear:YES];
 		
-        if ([_delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
-            [_delegate navigationController:self willShowViewController:topController animated:YES];
-        }
+		if ([_delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
+			[_delegate navigationController:self willShowViewController:topController animated:YES];
+		}
 		
 		[self.view insertSubview:topController.view atIndex:0];
 		
 	}
-    
+	
 	[self _setVisibleViewControllerNeedsUpdate];
 	
 	return formerTopViewController;
@@ -212,40 +212,40 @@ static const NSTimeInterval kAnimationDuration = 0.5;
 
 - (NSArray *)popToViewController:(TUIViewController *)viewController animated:(BOOL)animated
 {
-    NSMutableArray *popped = [[NSMutableArray alloc] init];
+	NSMutableArray *popped = [[NSMutableArray alloc] init];
 	
-    if ([_viewControllers containsObject:viewController]) {
-        while (self.topViewController != viewController) {
-            TUIViewController *poppedController = [self popViewControllerAnimated:animated];
-            if (poppedController) {
-                [popped addObject:poppedController];
-            } else {
-                break;
-            }
-        }
-    }
-    
-    return [popped copy];
+	if ([_viewControllers containsObject:viewController]) {
+		while (self.topViewController != viewController) {
+			TUIViewController *poppedController = [self popViewControllerAnimated:animated];
+			if (poppedController) {
+				[popped addObject:poppedController];
+			} else {
+				break;
+			}
+		}
+	}
+	
+	return [popped copy];
 }
 
 - (NSArray *)popToRootViewControllerAnimated:(BOOL)animated
 {
-    return [self popToViewController:[_viewControllers objectAtIndex:0] animated:animated];
+	return [self popToViewController:[_viewControllers objectAtIndex:0] animated:animated];
 }
 
 - (void)setViewControllers:(NSArray *)newViewControllers animated:(BOOL)animated {
 	assert([newViewControllers count] >= 1);
 	
-    if (![newViewControllers isEqualToArray:_viewControllers]) {
-        // remove them all in bulk
-        [_viewControllers makeObjectsPerformSelector:@selector(_setParentViewController:) withObject:nil];
-        [_viewControllers removeAllObjects];
-        
-        // add them back in one-by-one and only apply animation to the last one (if any)
-        for (TUIViewController *controller in newViewControllers) {
-            [self pushViewController:controller animated:(animated && (controller == [newViewControllers lastObject]))];
-        }
-    }
+	if (![newViewControllers isEqualToArray:_viewControllers]) {
+		// remove them all in bulk
+		[_viewControllers makeObjectsPerformSelector:@selector(_setParentViewController:) withObject:nil];
+		[_viewControllers removeAllObjects];
+		
+		// add them back in one-by-one and only apply animation to the last one (if any)
+		for (TUIViewController *controller in newViewControllers) {
+			[self pushViewController:controller animated:(animated && (controller == [newViewControllers lastObject]))];
+		}
+	}
 }
 
 - (void)_setVisibleViewControllerNeedsUpdate
@@ -270,29 +270,29 @@ static const NSTimeInterval kAnimationDuration = 0.5;
 {
 	// do some bookkeeping
 	_visibleViewControllerNeedsUpdate = NO;
-    TUIViewController *topViewController = self.topViewController;
-    
+	TUIViewController *topViewController = self.topViewController;
+	
 	// make sure the new top view is both loaded and set to appear in the correct place
 	topViewController.view.frame = [self _controllerFrameForTransition:_visibleViewControllerTransition];
-    
+	
 	if (_visibleViewControllerTransition == _TUINavigationControllerVisibleControllerTransitionNone) {
 		[_visibleViewController viewWillDisappear:NO];
 		[topViewController viewWillAppear:NO];
-        
-        if ([_delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
-            [_delegate navigationController:self willShowViewController:topViewController animated:NO];
-        }
-        
+		
+		if ([_delegate respondsToSelector:@selector(navigationController:willShowViewController:animated:)]) {
+			[_delegate navigationController:self willShowViewController:topViewController animated:NO];
+		}
+		
 		[_visibleViewController.view removeFromSuperview];
 		[self.view insertSubview:topViewController.view atIndex:0];
-        
+		
 		[_visibleViewController viewDidDisappear:NO];
 		[topViewController viewDidAppear:NO];
 		
-        if ([_delegate respondsToSelector:@selector(navigationController:didShowViewController:animated:)]) {
-            [_delegate navigationController:self didShowViewController:topViewController animated:NO];
-        }
-    } else {
+		if ([_delegate respondsToSelector:@selector(navigationController:didShowViewController:animated:)]) {
+			[_delegate navigationController:self didShowViewController:topViewController animated:NO];
+		}
+	} else {
 		if (block) {
 			TUIViewController *previouslyVisibleViewController = _visibleViewController;
 			const CGRect topControllerFrame = [self _controllerFrameForTransition:_TUINavigationControllerVisibleControllerTransitionNone];
@@ -332,9 +332,9 @@ static const NSTimeInterval kAnimationDuration = 0.5;
 								  }
 							  }];
 		}
-    }
+	}
 	_visibleViewController = topViewController;
-    
+	
 }
 
 @end

--- a/lib/UIKit/TUIViewController.h
+++ b/lib/UIKit/TUIViewController.h
@@ -18,6 +18,7 @@
 
 @class TUINavigationItem;
 @class TUIView;
+@class TUINavigationController;
 
 @interface TUIViewController : TUIResponder <NSCopying>
 {

--- a/lib/UIKit/TUIViewController.m
+++ b/lib/UIKit/TUIViewController.m
@@ -16,6 +16,7 @@
 
 #import "TUIViewController.h"
 #import "TUIView.h"
+#import "TUINavigationController.h"
 
 @implementation TUIViewController
 
@@ -61,15 +62,8 @@
 	// subclasses must implement
 }
 
-- (void)viewDidLoad
-{
-	
-}
-
-- (void)viewDidUnload
-{
-	
-}
+- (void)viewDidLoad { }
+- (void)viewDidUnload{ }
 
 - (BOOL)isViewLoaded
 {
@@ -110,6 +104,25 @@
 	self.view = v;
 	
 	return v;
+}
+
+
+//Borrowed from Chameleon's UIViewController port at
+//https://github.com/BigZaphod/Chameleon/blob/master/UIKit/Classes/UIViewController.m
+- (id)_nearestParentViewControllerThatIsKindOf:(Class)c
+{
+    TUIViewController *controller = _parentViewController;
+	
+    while (controller && ![controller isKindOfClass:c]) {
+        controller = [controller parentViewController];
+    }
+	
+    return controller;
+}
+
+- (TUINavigationController *)navigationController
+{
+    return [self _nearestParentViewControllerThatIsKindOf:[TUINavigationController class]];
 }
 
 @end


### PR DESCRIPTION
AppKit always sorely needed a way to manage multiple view controllers, but now TwUI has one!  TUINavigationController is based heavily on UINavigationController, and as such, borrows lots of code from [Chameleon's](http://chameleonproject.org/) UINavigationController implementation (duly noted in the header). 

There is no UI component to the class, seeing as the Mac already has the top bar of an NSWindow, and there's no need to ugly-up the framework with a TUINavigationBar class.

A demonstration of the class can be found [here](https://github.com/CodaFi/TUINavigationController).  
