### PR TITLE
TUIScrollView bug fixing

### DIFF
--- a/lib/UIKit/TUIScrollView.m
+++ b/lib/UIKit/TUIScrollView.m
@@ -979,6 +979,8 @@ static float clampBounce(float x) {
 		_throw.t = t;
 		
 		[self _startTimer:AnimationModeThrow];
+			
+		BOOL pulling = self._pulling;
 		
 		if(_pull.xPulling) {
 			_pull.xPulling = NO;
@@ -994,7 +996,7 @@ static float clampBounce(float x) {
 			_bounce.y = _pull.y;
 		}
 		
-    if(self._pulling && _scrollViewFlags.didChangeContentInset){
+    if(pulling && _scrollViewFlags.didChangeContentInset){
       _scrollViewFlags.didChangeContentInset = 0;
       _bounce.x += _contentInset.left;
       _bounce.y += _contentInset.top;

--- a/lib/UIKit/TUIScrollView.m
+++ b/lib/UIKit/TUIScrollView.m
@@ -980,7 +980,7 @@ static float clampBounce(float x) {
 		
 		[self _startTimer:AnimationModeThrow];
 			
-		BOOL pulling = self._pulling;
+		BOOL pulling = self._pulling; // prefetch the pulling state before resetting it
 		
 		if(_pull.xPulling) {
 			_pull.xPulling = NO;


### PR DESCRIPTION
When `TUIScrollView` starts "throwing", it should respect its `contentInset`. The original code checks `self._pulling && _scrollViewFlags.didChangeContentInset` before updating its bounce values.

However, when it calls `self._pulling`, which is implemented by returning `_pull.xPulling || _pull.yPulling`, the `xPulling` and `yPulling` flags have already been reset to `NO` by the code blocks above it. So the condition evaluation is always `NO` and the code won't get a chance to execute.

I fix this by simply prefetching the pulling state of `TUIScrollView` before resetting it.
