### PR TITLE
Fix removeTarget:action:forControlEvents: for TUIControl

### DIFF
--- a/lib/UIKit/TUIControl+TargetAction.m
+++ b/lib/UIKit/TUIControl+TargetAction.m
@@ -92,6 +92,8 @@
 			[targetActionsToRemove addObject:t];
 		}
 	}
+	
+	[[self _targetActions] removeObjectsInArray:targetActionsToRemove];
 }
 
 - (NSSet *)allTargets                                                                     // set may include NSNull to indicate at least one nil target


### PR DESCRIPTION
The `removeTarget:action:forControlEvents:` of `TUIControl` only kept record of the control target actions to be removed, but did not actually remove them.

This is simply fixed by adding a line which does the removing job.
