### PR TITLE
Added TUIScrollView delegate method scrollViewDidEndDecelerating:

### DIFF
--- a/lib/UIKit/TUIScrollView.h
+++ b/lib/UIKit/TUIScrollView.h
@@ -137,6 +137,7 @@ typedef enum {
 		unsigned int delegateScrollViewDidScroll:1;
 		unsigned int delegateScrollViewWillBeginDragging:1;
 		unsigned int delegateScrollViewDidEndDragging:1;
+		unsigned int delegateScrollViewDidEndDecelerating:1;
 		unsigned int delegateScrollViewWillShowScrollIndicator:1;
 		unsigned int delegateScrollViewDidShowScrollIndicator:1;
 		unsigned int delegateScrollViewWillHideScrollIndicator:1;
@@ -194,6 +195,7 @@ typedef enum {
 - (void)scrollViewDidScroll:(TUIScrollView *)scrollView;
 - (void)scrollViewWillBeginDragging:(TUIScrollView *)scrollView;
 - (void)scrollViewDidEndDragging:(TUIScrollView *)scrollView;
+- (void)scrollViewDidEndDecelerating:(TUIScrollView *)scrollView;
 
 - (void)scrollView:(TUIScrollView *)scrollView willShowScrollIndicator:(TUIScrollViewIndicator)indicator;
 - (void)scrollView:(TUIScrollView *)scrollView didShowScrollIndicator:(TUIScrollViewIndicator)indicator;

--- a/lib/UIKit/TUIScrollView.m
+++ b/lib/UIKit/TUIScrollView.m
@@ -130,6 +130,7 @@ static BOOL isAtleastLion = NO;
 	_scrollViewFlags.delegateScrollViewDidScroll = [_delegate respondsToSelector:@selector(scrollViewDidScroll:)];
 	_scrollViewFlags.delegateScrollViewWillBeginDragging = [_delegate respondsToSelector:@selector(scrollViewWillBeginDragging:)];
 	_scrollViewFlags.delegateScrollViewDidEndDragging = [_delegate respondsToSelector:@selector(scrollViewDidEndDragging:)];
+	_scrollViewFlags.delegateScrollViewDidEndDecelerating = [_delegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)];
 	_scrollViewFlags.delegateScrollViewWillShowScrollIndicator = [_delegate respondsToSelector:@selector(scrollView:willShowScrollIndicator:)];
 	_scrollViewFlags.delegateScrollViewDidShowScrollIndicator = [_delegate respondsToSelector:@selector(scrollView:didShowScrollIndicator:)];
 	_scrollViewFlags.delegateScrollViewWillHideScrollIndicator = [_delegate respondsToSelector:@selector(scrollView:willHideScrollIndicator:)];
@@ -772,6 +773,9 @@ static float clampBounce(float x) {
 		
 		if(fabsf(_bounce.vy) < 1.0 && fabsf(_bounce.y) < 1.0 && fabsf(_bounce.vx) < 1.0 && fabsf(_bounce.x) < 1.0) {
 			[self _stopTimer];
+			if (_scrollViewFlags.delegateScrollViewDidEndDecelerating) {
+				[_delegate scrollViewDidEndDecelerating:self];
+			}
 		}
 		
 		[self _updateScrollKnobs];
@@ -1170,6 +1174,9 @@ static float clampBounce(float x) {
 						// ignore - let the bounce finish (_updateBounce will kill the timer when it's ready)
 					} else {
 						[self _stopTimer];
+						if (_scrollViewFlags.delegateScrollViewDidEndDecelerating) {
+							[_delegate scrollViewDidEndDecelerating:self];
+						}
 					}
 				}
 				break;


### PR DESCRIPTION
If implemented by the delegate, the scroll view calls this method when the scrolling movement comes to a halt. Functionality mimics that of scrollViewDidEndDecelerating: in UIKit.
