### PR TITLE
Fix TUINSView not being deallocated

### DIFF
--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -100,6 +100,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
  */
 - (void)setUp;
 
+- (void)windowWillClose:(NSNotification *)notification;
 - (void)windowDidResignKey:(NSNotification *)notification;
 - (void)windowDidBecomeKey:(NSNotification *)notification;
 - (void)screenProfileOrBackingPropertiesDidChange:(NSNotification *)notification;
@@ -651,11 +652,18 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	// set up masking on the AppKit host view, and make ourselves the layout
 	// manager, so that we'll know when new sublayers are added
 	self.appKitHostView.layer.layoutManager = self;
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowWillClose:) name:NSWindowWillCloseNotification object:self.window];
 
 	#if ENABLE_NSVIEW_CLIPPING
 	self.appKitHostView.layer.mask = self.maskLayer;
 	[self recalculateNSViewClipping];
 	#endif
+}
+
+- (void)windowWillClose:(NSNotification *)notification {
+	// since the layer retains the layoutManger, we need to set it to nil to
+	// make sure TUINSView will be deallocated
+	self.appKitHostView.layer.layoutManager = nil;
 }
 
 - (void)didAddSubview:(NSView *)view {

--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -100,7 +100,6 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
  */
 - (void)setUp;
 
-- (void)windowWillClose:(NSNotification *)notification;
 - (void)windowDidResignKey:(NSNotification *)notification;
 - (void)windowDidBecomeKey:(NSNotification *)notification;
 - (void)screenProfileOrBackingPropertiesDidChange:(NSNotification *)notification;
@@ -270,6 +269,11 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	
 	if(newWindow == nil) {
 		[_rootView removeFromSuperview];
+		// since the layer retains the layoutManger, we need to set it to nil to
+		// make sure TUINSView will be deallocated
+		self.appKitHostView.layer.layoutManager = nil;
+	} else {
+		self.appKitHostView.layer.layoutManager = self;
 	}
 }
 
@@ -652,18 +656,11 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	// set up masking on the AppKit host view, and make ourselves the layout
 	// manager, so that we'll know when new sublayers are added
 	self.appKitHostView.layer.layoutManager = self;
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowWillClose:) name:NSWindowWillCloseNotification object:self.window];
 
 	#if ENABLE_NSVIEW_CLIPPING
 	self.appKitHostView.layer.mask = self.maskLayer;
 	[self recalculateNSViewClipping];
 	#endif
-}
-
-- (void)windowWillClose:(NSNotification *)notification {
-	// since the layer retains the layoutManger, we need to set it to nil to
-	// make sure TUINSView will be deallocated
-	self.appKitHostView.layer.layoutManager = nil;
 }
 
 - (void)didAddSubview:(NSView *)view {


### PR DESCRIPTION
This can be reproduced by following steps:
1. In `ExampleAppDelegate.m`, change 
   `[tableViewWindow setReleasedWhenClosed:FALSE]` to 
   `[tableViewWindow setReleasedWhenClosed:TRUE]`.
2. In `TUINSView.m`, add a breakpoint to the `dealloc` method.
3. Run the example, and close the table view window.

The breakpoint is expected to be hit, however it is not.

It seems to be a bug introduced by AppKit bridging, when the following line is invoked in the `setUp` method of `TUINSView`:

``` objective-c
self.appKitHostView.layer.layoutManager = self;
```

The layer retains the layoutManager, which is the instance of TUINSView, and never has a chance to release it. And that's why the instance is not deallocated.

I fixed it by adding an observer to `NSWindowWillCloseNotification`, where I could set layer's layoutManager to `nil` to make the layer release the TUINSView's instance.
