### PR TITLE
Fix TUINSView trackingView memory management

### DIFF
--- a/lib/UIKit/TUINSView+Private.h
+++ b/lib/UIKit/TUINSView+Private.h
@@ -22,6 +22,9 @@
  */
 @property (nonatomic, readonly, strong) NSView *appKitHostView;
 
+// The view currently tracking mouse events.
+@property (nonatomic, unsafe_unretained) TUIView *trackingView;
+
 /*
  * Informs the receiver that the clipping of a TUIViewNSViewContainer it is hosting has
  * changed, and asks it to update clipping paths accordingly.

--- a/lib/UIKit/TUINSView+Private.h
+++ b/lib/UIKit/TUINSView+Private.h
@@ -11,30 +11,22 @@
 
 #import "TUINSView.h"
 
-/*
- * Private functionality of TUINSView that needs to be exposed to other parts of
- * the framework.
- */
+// Private functionality of TUINSView that needs to be exposed to other parts of
+// the framework.
 @interface TUINSView ()
 
-/*
- * The layer-backed view which actually holds the AppKit hierarchy.
- */
+// The layer-backed view which actually holds the AppKit hierarchy.
 @property (nonatomic, readonly, strong) NSView *appKitHostView;
 
 // The view currently tracking mouse events.
 @property (nonatomic, unsafe_unretained) TUIView *trackingView;
 
-/*
- * Informs the receiver that the clipping of a TUIViewNSViewContainer it is hosting has
- * changed, and asks it to update clipping paths accordingly.
- */
+// Informs the receiver that the clipping of a TUIViewNSViewContainer it is hosting has
+// changed, and asks it to update clipping paths accordingly.
 - (void)recalculateNSViewClipping;
 
-/*
- * Informs the receiver that the ordering of a TUIViewNSViewContainer it is hosting has
- * changed, and asks it to reorder its subviews to match TwUI.
- */
+// Informs the receiver that the ordering of a TUIViewNSViewContainer it is hosting has
+// changed, and asks it to reorder its subviews to match TwUI.
 - (void)recalculateNSViewOrdering;
 
 - (TUIView *)viewForLocalPoint:(NSPoint)p;

--- a/lib/UIKit/TUINSView.h
+++ b/lib/UIKit/TUINSView.h
@@ -27,7 +27,6 @@
 {
 	TUIView *_hoverView;
 
-	__unsafe_unretained TUIView *_trackingView; // dragging view, weak
 	__unsafe_unretained TUIView *_hyperFocusView; // hyperfocus view, weak
 
 	TUIView *_hyperFadeView;

--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -114,6 +114,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 // these cannot be implicitly synthesized because they're from protocols/categories
 @synthesize hostView = _hostView;
 @synthesize appKitHostView = _appKitHostView;
+@synthesize trackingView = _trackingView;
 @synthesize rootView = _rootView;
 @synthesize maskLayer = _maskLayer;
 
@@ -433,8 +434,8 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 		// normal case
 	normal:
 		;
-		_trackingView = [self viewForEvent:event];
-		[_trackingView mouseDown:event];
+		self.trackingView = [self viewForEvent:event];
+		[self.trackingView mouseDown:event];
 	}
 	
 	[TUITooltipWindow endTooltip];
@@ -442,18 +443,18 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 
 - (void)mouseUp:(NSEvent *)event
 {
-	TUIView *lastTrackingView = _trackingView;
+	TUIView *lastTrackingView = self.trackingView;
 
-	_trackingView = nil;
+	self.trackingView = nil;
 
-	[lastTrackingView mouseUp:event]; // after _trackingView set to nil, will call mouseUp:fromSubview:
+	[lastTrackingView mouseUp:event]; // after trackingView is set to nil, will call mouseUp:fromSubview:
 	
 	[self _updateHoverViewWithEvent:event];
 }
 
 - (void)mouseDragged:(NSEvent *)event
 {
-	[_trackingView mouseDragged:event];
+	[self.trackingView mouseDragged:event];
 }
 
 - (void)mouseMoved:(NSEvent *)event
@@ -471,19 +472,19 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 
 - (void)rightMouseDown:(NSEvent *)event
 {
-	_trackingView = [self viewForEvent:event];
-	[_trackingView rightMouseDown:event];
+	self.trackingView = [self viewForEvent:event];
+	[self.trackingView rightMouseDown:event];
 	[TUITooltipWindow endTooltip];
 	[super rightMouseDown:event]; // we need to send this up the responder chain so that -menuForEvent: will get called for two-finger taps
 }
 
 - (void)rightMouseUp:(NSEvent *)event
 {
-	TUIView *lastTrackingView = _trackingView;
+	TUIView *lastTrackingView = self.trackingView;
 	
-	_trackingView = nil;
+	self.trackingView = nil;
 	
-	[lastTrackingView rightMouseUp:event]; // after _trackingView set to nil, will call mouseUp:fromSubview:
+	[lastTrackingView rightMouseUp:event]; // after trackingView is set to nil, will call mouseUp:fromSubview:
 }
 
 - (void)scrollWheel:(NSEvent *)event
@@ -554,7 +555,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 
 - (BOOL)isTrackingSubviewOfView:(TUIView *)v
 {
-	return [_trackingView isDescendantOfView:v];
+	return [self.trackingView isDescendantOfView:v];
 }
 
 - (BOOL)isHoveringSubviewOfView:(TUIView *)v

--- a/lib/UIKit/TUIView.m
+++ b/lib/UIKit/TUIView.m
@@ -20,6 +20,7 @@
 #import "TUIView.h"
 #import "TUILayoutManager.h"
 #import "TUINSView.h"
+#import "TUINSView+Private.h"
 #import "TUINSWindow.h"
 #import "TUITextRenderer.h"
 #import "TUIViewController.h"
@@ -130,6 +131,8 @@ static pthread_key_t TUICurrentContextScaleFactorTLSKey;
 {
     [[TUILayoutManager sharedLayoutManager] removeLayoutConstraintsFromView:self];
     [[TUILayoutManager sharedLayoutManager] setLayoutName:nil forView:self];
+
+	if (self.nsView.trackingView == self) self.nsView.trackingView = nil;
     
 	[self setTextRenderers:nil];
 	_layer.delegate = nil;

--- a/lib/UIKit/TUIView.m
+++ b/lib/UIKit/TUIView.m
@@ -129,8 +129,8 @@ static pthread_key_t TUICurrentContextScaleFactorTLSKey;
 
 - (void)dealloc
 {
-    [[TUILayoutManager sharedLayoutManager] removeLayoutConstraintsFromView:self];
-    [[TUILayoutManager sharedLayoutManager] setLayoutName:nil forView:self];
+	[[TUILayoutManager sharedLayoutManager] removeLayoutConstraintsFromView:self];
+	[[TUILayoutManager sharedLayoutManager] setLayoutName:nil forView:self];
 
 	if (self.nsView.trackingView == self) self.nsView.trackingView = nil;
     


### PR DESCRIPTION
The tracking view needs to be zeroed out if the view itself is deallocated. This can happen with extremely quick multi-click interactions.
