### PR TITLE
TUIView Multitouch Support

### DIFF
--- a/ExampleProject/Example/ExampleTabBar.h
+++ b/ExampleProject/Example/ExampleTabBar.h
@@ -19,23 +19,20 @@
 @class ExampleTabBar;
 
 @protocol ExampleTabBarDelegate <NSObject>
+
 @required
 - (void)tabBar:(ExampleTabBar *)tabBar didSelectTab:(NSInteger)index;
+
 @end
 
-/*
- An example of how to build a custom UI control, in this case a simple tab bar
- */
-
+// An example of how to build a custom UI control, in this case a simple tab bar.
 @interface ExampleTabBar : TUIView
-{
-	id<ExampleTabBarDelegate> __unsafe_unretained delegate;
-	NSArray *tabViews;
-}
 
-- (id)initWithNumberOfTabs:(NSInteger)nTabs;
+- (id)initWithNumberOfTabs:(NSUInteger)count;
 
 @property (nonatomic, unsafe_unretained) id<ExampleTabBarDelegate> delegate;
 @property (nonatomic, readonly) NSArray *tabViews;
+
+- (BOOL)isHighlightingTab:(TUIView *)tab;
 
 @end

--- a/ExampleProject/Example/ExampleTabBar.m
+++ b/ExampleProject/Example/ExampleTabBar.m
@@ -93,6 +93,32 @@
 	}];
 }
 
+// End control tracking when cancelled for any reason.
+- (void)cancelTrackingWithEvent:(NSEvent *)event {
+	[self endTrackingWithEvent:event];
+}
+
+- (void)touchesBeganWithEvent:(NSEvent *)event {
+	if([self touchesMatchingPhase:NSTouchPhaseTouching forEvent:event].count == 2) {
+		NSLog(@"tapped");
+	}
+}
+
+- (void)touchesMovedWithEvent:(NSEvent *)event {
+	if([self touchesMatchingPhase:NSTouchPhaseTouching forEvent:event].count == 2) {
+		NSLog(@"swiped");
+	}
+}
+
+- (void)touchesEndedWithEvent:(NSEvent *)event {
+	NSLog(@"untapped");
+}
+
+// End touch tracking when cancelled for any reason.
+- (void)touchesCancelledWithEvent:(NSEvent *)event {
+	[self touchesEndedWithEvent:event];
+}
+
 @end
 
 @interface ExampleTabBar ()
@@ -112,6 +138,9 @@
 		NSMutableArray *_tabViews = [NSMutableArray arrayWithCapacity:nTabs];
 		for(int i = 0; i < nTabs; ++i) {
 			ExampleTab *t = [[ExampleTab alloc] initWithFrame:CGRectZero];
+			t.acceptsTouchEvents = YES;
+			t.wantsRestingTouches = YES;
+			
 			t.tag = i;
 			t.layout = ^(TUIView *v) { // the layout of an individual tab is a function of the superview bounds, the number of tabs, and the current tab index
 				CGRect b = v.superview.bounds; // reference the passed-in 'v' rather than 't' to avoid a retain cycle
@@ -119,6 +148,7 @@
 				float x = i * width;
 				return CGRectMake(roundf(x), 0, roundf(width), b.size.height);
 			};
+			
 			[self addSubview:t];
 			[_tabViews addObject:t];
 		}
@@ -129,23 +159,20 @@
 }
 
 
-- (void)drawRect:(CGRect)rect
-{
-	// draw tab bar background
-	
-	CGRect b = self.bounds;
+- (void)drawRect:(CGRect)rect {
 	CGContextRef ctx = TUIGraphicsGetCurrentContext();
 	
-	// gray gradient
+	// Tab Bar Gradient
 	CGFloat colorA[] = { 0.85, 0.85, 0.85, 1.0 };
 	CGFloat colorB[] = { 0.71, 0.71, 0.71, 1.0 };
-	CGContextDrawLinearGradientBetweenPoints(ctx, CGPointMake(0, b.size.height), colorA, CGPointMake(0, 0), colorB);
+	CGContextDrawLinearGradientBetweenPoints(ctx, CGPointMake(0, CGRectGetHeight(self.bounds)),
+											 colorA, CGPointMake(0, 0), colorB);
 	
-	// top emboss
+	// Separator Etching
 	CGContextSetRGBFillColor(ctx, 1, 1, 1, 0.5);
-	CGContextFillRect(ctx, CGRectMake(0, b.size.height-2, b.size.width, 1));
+	CGContextFillRect(ctx, CGRectMake(0, self.bounds.size.height-2, self.bounds.size.width, 1));
 	CGContextSetRGBFillColor(ctx, 0, 0, 0, 0.3);
-	CGContextFillRect(ctx, CGRectMake(0, b.size.height-1, b.size.width, 1));
+	CGContextFillRect(ctx, CGRectMake(0, self.bounds.size.height-1, self.bounds.size.width, 1));
 }
 
 @end

--- a/ExampleProject/Example/ExampleTabBar.m
+++ b/ExampleProject/Example/ExampleTabBar.m
@@ -19,6 +19,7 @@
 @interface ExampleTab : TUIControl
 
 @property (nonatomic, assign) CGFloat originalPosition;
+@property (nonatomic, strong) NSTimer *flashTimer;
 
 @end
 
@@ -47,19 +48,11 @@
 - (BOOL)continueTrackingWithEvent:(NSEvent *)event {
 	
 	// Offset the tab's x origin by whatever we dragged by.
-	// Animating it makes it fun if the drag goes pretty far.
-	CGFloat currentPosition = [self convertPoint:[event locationInWindow] fromView:nil].x;
-	[TUIView animateWithDuration:0.1 animations:^{
-		
-		// Setting an ease-in-out animation curve slows down
-		// the animation at the start and finish, but speeds it up
-		// during the middle. Just for that "don't slide me!" fun.
-		[TUIView setAnimationCurve:TUIViewAnimationCurveEaseInOut];
-		
-		CGRect draggedRect = self.frame;
-		draggedRect.origin.x += roundf(currentPosition - self.originalPosition);
-		self.frame = draggedRect;
-	}];
+	CGFloat currentPosition = [self convertPoint:event.locationInWindow fromView:nil].x;
+	
+	CGRect draggedRect = self.frame;
+	draggedRect.origin.x += roundf(currentPosition - self.originalPosition);
+	self.frame = draggedRect;
 	
 	return YES;
 }
@@ -70,21 +63,21 @@
 	// By nature, the event *must* be inside the tab's bounds, otherwise the
 	// tracking process will not be invoked. If we were dragged, we were NOT
 	// pressed, so don't call the delegate.
-	CGFloat currentPosition = [self convertPoint:[event locationInWindow] fromView:nil].x;
+	CGFloat currentPosition = [self convertPoint:event.locationInWindow fromView:nil].x;
 	if(self.originalPosition == currentPosition)
-		[[self tabBar].delegate tabBar:[self tabBar] didSelectTab:self.tag];
+		[self.tabBar.delegate tabBar:self.tabBar didSelectTab:self.tag];
 	
 	// Since tracking is done, move the tab back. This whole ordeal lets us
 	// "stretch" our tabs around.
-	float originalPoint = self.tag * (self.tabBar.bounds.size.width / self.tabBar.tabViews.count);
-	[TUIView animateWithDuration:0.2 animations:^{
+	CGFloat originalPoint = self.tag * (self.tabBar.bounds.size.width / self.tabBar.tabViews.count);
+	[TUIView animateWithDuration:0.25f animations:^{
 		CGRect draggedRect = self.frame;
 		draggedRect.origin.x = roundf(originalPoint);
 		self.frame = draggedRect;
 	}];
 	
 	// Rather than a simple -setNeedsDisplay, let's fade it back out.
-	[TUIView animateWithDuration:0.3 animations:^{
+	[TUIView animateWithDuration:0.25f animations:^{
 		
 		// -redraw forces a .contents update immediately based on drawRect,
 		// and it happens inside an animation block, so CoreAnimation gives
@@ -98,25 +91,51 @@
 	[self endTrackingWithEvent:event];
 }
 
+// When the tab is tapped with two fingers, let it pulse, otherwise
+// do nothing. To let it pulse, use the selected property and toggle it.
 - (void)touchesBeganWithEvent:(NSEvent *)event {
-	if([self touchesMatchingPhase:NSTouchPhaseTouching forEvent:event].count == 2) {
-		NSLog(@"tapped");
-	}
+	if([self touchesMatchingPhase:NSTouchPhaseTouching forEvent:event].count != 2)
+		return;
+	
+	// Using -redraw within an animation block lets us crossfade
+	// the tab selection. When we finish this animation, queue
+	// the pulsing with a timer set repeat the -flash method.
+	[TUIView animateWithDuration:0.25f animations:^{
+		self.selected = YES;
+		[self redraw];
+	} completion:^(BOOL finished) {
+		if(finished) {
+			self.flashTimer = [NSTimer scheduledTimerWithTimeInterval:0.25f
+															   target:self selector:@selector(flash)
+															 userInfo:nil repeats:YES];
+		}
+	}];
 }
 
-- (void)touchesMovedWithEvent:(NSEvent *)event {
-	if([self touchesMatchingPhase:NSTouchPhaseTouching forEvent:event].count == 2) {
-		NSLog(@"swiped");
-	}
-}
-
+// If the touches have ended, invalidate the timer and animate
+// back to the standard state, setting .selected as NO.
 - (void)touchesEndedWithEvent:(NSEvent *)event {
-	NSLog(@"untapped");
+	[self.flashTimer invalidate];
+	self.flashTimer = nil;
+	
+	[TUIView animateWithDuration:0.25f animations:^{
+		self.selected = NO;
+		[self redraw];
+	}];
 }
 
 // End touch tracking when cancelled for any reason.
 - (void)touchesCancelledWithEvent:(NSEvent *)event {
 	[self touchesEndedWithEvent:event];
+}
+
+// This method, called from a timer, should pulse the tab by
+// flipping the .selected property value, and animating the change.
+- (void)flash {
+	[TUIView animateWithDuration:0.25f animations:^{
+		self.selected = !self.selected;
+		[self redraw];
+	}];
 }
 
 @end
@@ -129,31 +148,30 @@
 
 @implementation ExampleTabBar
 
-@synthesize delegate;
-@synthesize tabViews;
-
-- (id)initWithNumberOfTabs:(NSInteger)nTabs
-{
+- (id)initWithNumberOfTabs:(NSUInteger)count {
 	if((self = [super initWithFrame:CGRectZero])) {
-		NSMutableArray *_tabViews = [NSMutableArray arrayWithCapacity:nTabs];
-		for(int i = 0; i < nTabs; ++i) {
-			ExampleTab *t = [[ExampleTab alloc] initWithFrame:CGRectZero];
-			t.acceptsTouchEvents = YES;
-			t.wantsRestingTouches = YES;
+		NSMutableArray *tabs = [NSMutableArray arrayWithCapacity:count];
+		
+		for(int i = 0; i < count; ++i) {
+			ExampleTab *tab = [[ExampleTab alloc] initWithFrame:CGRectZero];
+			tab.acceptsTouchEvents = YES;
+			tab.wantsRestingTouches = YES;
+			tab.tag = i;
 			
-			t.tag = i;
-			t.layout = ^(TUIView *v) { // the layout of an individual tab is a function of the superview bounds, the number of tabs, and the current tab index
-				CGRect b = v.superview.bounds; // reference the passed-in 'v' rather than 't' to avoid a retain cycle
-				float width = (b.size.width / nTabs);
-				float x = i * width;
-				return CGRectMake(roundf(x), 0, roundf(width), b.size.height);
+			// The layout of an individual tab is a function of the superview bounds,
+			// the number of tabs, and the current tab index.
+			// Reference the passed-in 'view' rather than 'tab' to avoid a retain cycle.
+			tab.layout = ^(TUIView *view) {
+				CGRect rect = view.superview.bounds;
+				CGFloat width = (rect.size.width / count);
+				return CGRectMake(roundf(i * width), 0, roundf(width), CGRectGetHeight(rect));
 			};
 			
-			[self addSubview:t];
-			[_tabViews addObject:t];
+			[self addSubview:tab];
+			[tabs addObject:tab];
 		}
 		
-		tabViews = [[NSArray alloc] initWithArray:_tabViews];
+		_tabViews = [[NSArray alloc] initWithArray:tabs];
 	}
 	return self;
 }
@@ -162,17 +180,26 @@
 - (void)drawRect:(CGRect)rect {
 	CGContextRef ctx = TUIGraphicsGetCurrentContext();
 	
-	// Tab Bar Gradient
-	CGFloat colorA[] = { 0.85, 0.85, 0.85, 1.0 };
-	CGFloat colorB[] = { 0.71, 0.71, 0.71, 1.0 };
+	// Drawing the bar gradient using CGContextRef functions.
+	CGFloat colorA[] = { 0.85f, 0.85f, 0.85f, 1.0f };
+	CGFloat colorB[] = { 0.71f, 0.71f, 0.71f, 1.0f };
 	CGContextDrawLinearGradientBetweenPoints(ctx, CGPointMake(0, CGRectGetHeight(self.bounds)),
 											 colorA, CGPointMake(0, 0), colorB);
 	
-	// Separator Etching
-	CGContextSetRGBFillColor(ctx, 1, 1, 1, 0.5);
-	CGContextFillRect(ctx, CGRectMake(0, self.bounds.size.height-2, self.bounds.size.width, 1));
-	CGContextSetRGBFillColor(ctx, 0, 0, 0, 0.3);
-	CGContextFillRect(ctx, CGRectMake(0, self.bounds.size.height-1, self.bounds.size.width, 1));
+	// Drawing the separator etch using Cocoa Graphics objects.
+	[[NSColor colorWithCalibratedWhite:1.0f alpha:0.5f] set];
+	[[NSBezierPath bezierPathWithRect:CGRectMake(0, CGRectGetHeight(self.bounds) - 2, CGRectGetWidth(self.bounds), 1)] fill];
+	[[NSColor colorWithCalibratedWhite:0.0f alpha:0.25f] set];
+	[[NSBezierPath bezierPathWithRect:CGRectMake(0, CGRectGetHeight(self.bounds) - 1, CGRectGetWidth(self.bounds), 1)] fill];
+}
+
+- (BOOL)isHighlightingTab:(TUIView *)tab {
+	if(![self.tabViews containsObject:tab])
+		return NO;
+	
+	if([(ExampleTab *)tab state] & (TUIControlStateHighlighted | TUIControlStateSelected))
+		return YES;
+	else return NO;
 }
 
 @end

--- a/ExampleProject/Example/ExampleView.m
+++ b/ExampleProject/Example/ExampleView.m
@@ -61,12 +61,13 @@
 			// let's just teach the tabs how to draw themselves right here - no need to subclass anything
 			tabView.drawRect = ^(TUIView *v, CGRect rect) {
 				CGRect b = v.bounds;
+				ExampleTabBar *bar = (ExampleTabBar *)v.superview;
 				CGContextRef ctx = TUIGraphicsGetCurrentContext();
 				
 				NSImage *image = [NSImage imageNamed:@"clock"];
 				CGRect imageRect = ABIntegralRectWithSizeCenteredInRect([image size], b);
 
-				if([v.nsView isTrackingSubviewOfView:v]) { // simple way to check if the mouse is currently down inside of 'v'.  See the other methods in TUINSView for more.
+				if([bar isHighlightingTab:v]) {
 					
 					// first draw a slight white emboss below
 					CGContextSaveGState(ctx);

--- a/lib/UIKit/TUIControl.h
+++ b/lib/UIKit/TUIControl.h
@@ -98,6 +98,11 @@ typedef enum TUIControlState : NSUInteger {
 // opts to cancel it - only when the user cancels the tracking.
 - (void)endTrackingWithEvent:(NSEvent *)event;
 
+// When control tracking ends, this method is called to allow
+// the control to clean up. It is NOT called when the control
+// opts to cancel it - only when the user cancels the tracking.
+- (void)cancelTrackingWithEvent:(NSEvent *)event;
+
 @end
 
 @interface TUIControl (TargetAction)

--- a/lib/UIKit/TUIControl.m
+++ b/lib/UIKit/TUIControl.m
@@ -208,7 +208,7 @@
 		_controlFlags.tracking = 0;
 		[self _stateDidChange];
 
-		[self endTrackingWithEvent:nil];
+		[self cancelTrackingWithEvent:nil];
 		[self setNeedsDisplay];
 	}
 }
@@ -219,7 +219,18 @@
 		_controlFlags.tracking = 0;
 		[self _stateDidChange];
 
-		[self endTrackingWithEvent:nil];
+		[self cancelTrackingWithEvent:nil];
+		[self setNeedsDisplay];
+	}
+}
+
+- (void)windowDidResignKey {
+	if(!_controlFlags.disabled && _controlFlags.tracking) {
+		[self _stateWillChange];
+		_controlFlags.tracking = 0;
+		[self _stateDidChange];
+		
+		[self cancelTrackingWithEvent:nil];
 		[self setNeedsDisplay];
 	}
 }
@@ -234,6 +245,10 @@
 }
 
 - (void)endTrackingWithEvent:(NSEvent *)event {
+	return;
+}
+
+- (void)cancelTrackingWithEvent:(NSEvent *)event {
 	return;
 }
 

--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -517,10 +517,12 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 			// If the view does not exist, we've reached the top of
 			// the heirarchy, and still have not found a view willing
 			// to accept touches, so simply return early. If not,
-			// check if it's willing to accept touch events.
+			// check if it's willing to accept touch events, and has
+			// successfully implemented -touchesBeganWithEvent:.
 			if(touchView == nil) {
 				return;
-			} else if(touchView->_viewFlags.acceptsTouchEvents) {
+			} else if(touchView->_viewFlags.acceptsTouchEvents &&
+					  [touchView respondsToSelector:@selector(touchesBeganWithEvent:)]) {
 				self.lastTouchView = touchView;
 				break;
 			}

--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -123,8 +123,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 @synthesize rootView = _rootView;
 @synthesize maskLayer = _maskLayer;
 
-- (id)initWithCoder:(NSCoder *)coder
-{
+- (id)initWithCoder:(NSCoder *)coder {
 	self = [super initWithCoder:coder];
 	if (self == nil)
 		return nil;
@@ -133,8 +132,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	return self;
 }
 
-- (id)initWithFrame:(NSRect)frameRect
-{
+- (id)initWithFrame:(NSRect)frameRect {
 	self = [super initWithFrame:frameRect];
 	if (self == nil)
 		return nil;
@@ -143,8 +141,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	return self;
 }
 
-- (void)dealloc
-{
+- (void)dealloc {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
 	
 	_rootView.hostView = nil;
@@ -158,33 +155,28 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	
 }
 
-- (void)resetCursorRects
-{
+- (void)resetCursorRects {
 	NSRect f = [self frame];
 	f.origin = NSZeroPoint;
 	[self addCursorRect:f cursor:[NSCursor arrowCursor]];
 }
 
-- (void)tui_setOpaque:(BOOL)o
-{
+- (void)tui_setOpaque:(BOOL)o {
 	opaque = o;
 }
 
-- (BOOL)isOpaque
-{
+- (BOOL)isOpaque {
 	return opaque;
 }
 
-- (BOOL)mouseDownCanMoveWindow
-{
+- (BOOL)mouseDownCanMoveWindow {
 	return NO;
 }
 
-- (void)updateTrackingAreas
-{
+- (void)updateTrackingAreas {
 	[super updateTrackingAreas];
 	
-	if(_trackingArea) {
+	if (_trackingArea) {
 		[self removeTrackingArea:_trackingArea];
 	}
 	
@@ -194,30 +186,26 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	[self addTrackingArea:_trackingArea];
 }
 
-- (void)viewWillStartLiveResize
-{
+- (void)viewWillStartLiveResize {
 	[super viewWillStartLiveResize];
 	inLiveResize = YES;
 	[_rootView viewWillStartLiveResize];
 }
 
-- (BOOL)inLiveResize
-{
+- (BOOL)inLiveResize {
 	return inLiveResize;
 }
 
-- (void)viewDidEndLiveResize
-{
+- (void)viewDidEndLiveResize {
 	[super viewDidEndLiveResize];
 	inLiveResize = NO;
 	[_rootView viewDidEndLiveResize]; // will send to all subviews
 	
-	if([[self window] respondsToSelector:@selector(ensureWindowRectIsOnScreen)])
+	if ([[self window] respondsToSelector:@selector(ensureWindowRectIsOnScreen)])
 		[[self window] performSelector:@selector(ensureWindowRectIsOnScreen)];
 }
 
-- (void)setRootView:(TUIView *)v
-{
+- (void)setRootView:(TUIView *)v {
 	v.autoresizingMask = TUIViewAutoresizingFlexibleSize;
 
 	TUINSView *originalNSView = v.ancestorTUINSView;
@@ -247,10 +235,9 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	[v didMoveFromTUINSView:originalNSView];
 }
 
-- (void)setNextResponder:(NSResponder *)r
-{
+- (void)setNextResponder:(NSResponder *)r {
 	NSResponder *nextResponder = [self nextResponder];
-	if([nextResponder isKindOfClass:[NSViewController class]]) {
+	if ([nextResponder isKindOfClass:[NSViewController class]]) {
 		// keep view controller in chain
 		[nextResponder setNextResponder:r];
 	} else {
@@ -259,21 +246,21 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 }
 
 - (void)viewWillMoveToWindow:(NSWindow *)newWindow {
-	if(self.window != nil) {
+	if (self.window != nil) {
 		[[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowDidBecomeKeyNotification object:self.window];
 		[[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowDidResignKeyNotification object:self.window];
 		[[NSNotificationCenter defaultCenter] removeObserver:self name:NSWindowDidChangeScreenProfileNotification object:self.window];
 	}
 	
 	CALayer *hostLayer = self.layer;
-	if(newWindow != nil && _rootView.layer.superlayer != hostLayer) {
+	if (newWindow != nil && _rootView.layer.superlayer != hostLayer) {
 		_rootView.layer.frame = hostLayer.bounds;
 		[hostLayer insertSublayer:_rootView.layer atIndex:0];
 	}
 	
 	[self.rootView willMoveToWindow:(TUINSWindow *) newWindow];
 	
-	if(newWindow == nil) {
+	if (newWindow == nil) {
 		[_rootView removeFromSuperview];
 		// since the layer retains the layoutManger, we need to set it to nil to
 		// make sure TUINSView will be deallocated
@@ -283,13 +270,12 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	}
 }
 
-- (void)viewDidMoveToWindow
-{
+- (void)viewDidMoveToWindow {
 	[self _updateLayerScaleFactor];
 	
 	[self.rootView didMoveToWindow];
 	
-	if(self.window != nil) {
+	if (self.window != nil) {
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidResignKey:) name:NSWindowDidResignKeyNotification object:self.window];
 		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(windowDidBecomeKey:) name:NSWindowDidBecomeKeyNotification object:self.window];
 		
@@ -300,14 +286,14 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 }
 
 - (void)_updateLayerScaleFactor {
-	if([self window] != nil) {
+	if ([self window] != nil) {
 		CGFloat scale = 1.0f;
-		if([[self window] respondsToSelector:@selector(backingScaleFactor)]) {
+		if ([[self window] respondsToSelector:@selector(backingScaleFactor)]) {
 			scale = [[self window] backingScaleFactor];
 		}
 		
-		if([self.layer respondsToSelector:@selector(setContentsScale:)]) {
-			if(fabs(self.layer.contentsScale - scale) > 0.1f) {
+		if ([self.layer respondsToSelector:@selector(setContentsScale:)]) {
+			if (fabs(self.layer.contentsScale - scale) > 0.1f) {
 				self.layer.contentsScale = scale;
 			}
 		}
@@ -316,78 +302,68 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	}
 }
 
-- (void)screenProfileOrBackingPropertiesDidChange:(NSNotification *)notification
-{
+- (void)screenProfileOrBackingPropertiesDidChange:(NSNotification *)notification {
 	[self performSelector:@selector(_updateLayerScaleFactor) withObject:nil afterDelay:0.0]; // the window's backingScaleFactor doesn't update until after this notification fires (10.8) - so delay it a bit.
 }
 
-- (TUIView *)viewForLocalPoint:(NSPoint)p
-{
+- (TUIView *)viewForLocalPoint:(NSPoint)p {
 	return [_rootView hitTest:p withEvent:nil];
 }
 
-- (NSPoint)localPointForLocationInWindow:(NSPoint)locationInWindow
-{
+- (NSPoint)localPointForLocationInWindow:(NSPoint)locationInWindow {
 	return [self convertPoint:locationInWindow fromView:nil];
 }
 
-- (TUIView *)viewForLocationInWindow:(NSPoint)locationInWindow
-{
+- (TUIView *)viewForLocationInWindow:(NSPoint)locationInWindow {
 	return [self viewForLocalPoint:[self localPointForLocationInWindow:locationInWindow]];
 }
 
-- (TUIView *)viewForEvent:(NSEvent *)event
-{
+- (TUIView *)viewForEvent:(NSEvent *)event {
 	return [self viewForLocationInWindow:[event locationInWindow]];
 }
 
-- (void)windowDidResignKey:(NSNotification *)notification
-{
+- (void)windowDidResignKey:(NSNotification *)notification {
 	[TUITooltipWindow endTooltip];
 	
-	if(![self isWindowKey]) {
+	if (![self isWindowKey]) {
 		[self.rootView windowDidResignKey];
 	}
 }
 
-- (void)windowDidBecomeKey:(NSNotification *)notification
-{
+- (void)windowDidBecomeKey:(NSNotification *)notification {
 	[self.rootView windowDidBecomeKey];
 }
 
-- (BOOL)isWindowKey
-{
-	if([self.window isKeyWindow]) return YES;
+- (BOOL)isWindowKey {
+	if ([self.window isKeyWindow]) return YES;
 	
 	NSWindow *keyWindow = [NSApp keyWindow];
-	if(keyWindow == nil) return NO;
+	if (keyWindow == nil) return NO;
 	
 	return keyWindow == [self.window attachedSheet];
 }
 
-- (void)viewWillMoveToSuperview:(NSView *)newSuperview
-{
+- (void)viewWillMoveToSuperview:(NSView *)newSuperview {
 	[super viewWillMoveToSuperview:newSuperview];
 	
-	if(newSuperview == nil) {
+	if (newSuperview == nil) {
 		[TUITooltipWindow endTooltip];
 	}
 }
 
-- (void)_updateHoverView:(TUIView *)_newHoverView withEvent:(NSEvent *)event
-{
-	if(_hyperFocusView) {
-		if(![_newHoverView isDescendantOfView:_hyperFocusView]) {
+- (void)_updateHoverView:(TUIView *)_newHoverView withEvent:(NSEvent *)event {
+	if (_hyperFocusView) {
+		if (![_newHoverView isDescendantOfView:_hyperFocusView]) {
 			_newHoverView = nil; // don't allow hover
 		}
 	}
 	
-	if(_newHoverView != _hoverView) {
+	if (_newHoverView != _hoverView) {
 		[_hoverView mouseExited:event];
 		[_newHoverView mouseEntered:event];
 		_hoverView = _newHoverView;
 		
-		if([[self window] isKeyWindow]) {
+		if ([[self window] isKeyWindow]) {
 			[TUITooltipWindow updateTooltip:_hoverView.toolTip delay:_hoverView.toolTipDelay];
 		} else {
 			[TUITooltipWindow updateTooltip:nil delay:_hoverView.toolTipDelay];
@@ -397,12 +373,11 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	}
 }
 
-- (void)_updateHoverViewWithEvent:(NSEvent *)event
-{
+- (void)_updateHoverViewWithEvent:(NSEvent *)event {
 	TUIView *_newHoverView = [self viewForEvent:event];
 	
-	if(![[self window] isKeyWindow]) {
-		if(![_newHoverView acceptsFirstMouse:event]) {
+	if (![[self window] isKeyWindow]) {
+		if (![_newHoverView acceptsFirstMouse:event]) {
 			// in background, don't do hover for things that don't accept first mouse
 			_newHoverView = nil;
 		}
@@ -411,23 +386,20 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	[self _updateHoverView:_newHoverView withEvent:event];
 }
 
-- (void)invalidateHover
-{
+- (void)invalidateHover {
 	[self _updateHoverView:nil withEvent:nil];
 }
 
-- (void)invalidateHoverForView:(TUIView *)v
-{
-	if([_hoverView isDescendantOfView:v]) {
+- (void)invalidateHoverForView:(TUIView *)v {
+	if ([_hoverView isDescendantOfView:v]) {
 		[self invalidateHover];
 	}
 }
 
-- (void)mouseDown:(NSEvent *)event
-{
-	if(_hyperFocusView) {
+- (void)mouseDown:(NSEvent *)event {
+	if (_hyperFocusView) {
 		TUIView *v = [self viewForEvent:event];
-		if([v isDescendantOfView:_hyperFocusView]) {
+		if ([v isDescendantOfView:_hyperFocusView]) {
 			// activate it normally
 			[self endHyperFocus:NO]; // not cancelled
 			goto normal;
@@ -446,8 +418,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	[TUITooltipWindow endTooltip];
 }
 
-- (void)mouseUp:(NSEvent *)event
-{
+- (void)mouseUp:(NSEvent *)event {
 	TUIView *lastTrackingView = self.trackingView;
 
 	self.trackingView = nil;
@@ -457,13 +428,11 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	[self _updateHoverViewWithEvent:event];
 }
 
-- (void)mouseDragged:(NSEvent *)event
-{
+- (void)mouseDragged:(NSEvent *)event {
 	[self.trackingView mouseDragged:event];
 }
 
-- (void)mouseMoved:(NSEvent *)event
-{
+- (void)mouseMoved:(NSEvent *)event {
 	[self _updateHoverViewWithEvent:event];
 }
 
@@ -475,16 +444,14 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
   [self _updateHoverViewWithEvent:event];
 }
 
-- (void)rightMouseDown:(NSEvent *)event
-{
+- (void)rightMouseDown:(NSEvent *)event {
 	self.trackingView = [self viewForEvent:event];
 	[self.trackingView rightMouseDown:event];
 	[TUITooltipWindow endTooltip];
 	[super rightMouseDown:event]; // we need to send this up the responder chain so that -menuForEvent: will get called for two-finger taps
 }
 
-- (void)rightMouseUp:(NSEvent *)event
-{
+- (void)rightMouseUp:(NSEvent *)event {
 	TUIView *lastTrackingView = self.trackingView;
 	
 	self.trackingView = nil;
@@ -492,8 +459,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	[lastTrackingView rightMouseUp:event]; // after trackingView is set to nil, will call mouseUp:fromSubview:
 }
 
-- (void)scrollWheel:(NSEvent *)event
-{
+- (void)scrollWheel:(NSEvent *)event {
 	[[self viewForEvent:event] scrollWheel:event];
 	[self _updateHoverView:nil withEvent:event]; // don't pop in while scrolling
 }
@@ -505,7 +471,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 - (void)touchesBeganWithEvent:(NSEvent *)event {
 	
 	// If we're already delivering an event, or there was no view, don't process it.
-	if(!deliveringEvent) {
+	if (!deliveringEvent) {
 		
 		// Get the view for which the touch began at if there is one,
 		// and check whether the view can actually receive touch events.
@@ -519,9 +485,9 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 			// to accept touches, so simply return early. If not,
 			// check if it's willing to accept touch events, and has
 			// successfully implemented -touchesBeganWithEvent:.
-			if(touchView == nil) {
+			if (touchView == nil) {
 				return;
-			} else if(touchView->_viewFlags.acceptsTouchEvents &&
+			} else if (touchView->_viewFlags.acceptsTouchEvents &&
 					  [touchView respondsToSelector:@selector(touchesBeganWithEvent:)]) {
 				self.lastTouchView = touchView;
 				break;
@@ -536,7 +502,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 		// If a resting touch was detected, and the view supports it,
 		// or there was no resting touch detected, forward the event.
 		// Block the internal event forwarding chain while doing this.
-		if(allowRestingTouchIfPossible) {
+		if (allowRestingTouchIfPossible) {
 			deliveringEvent = YES;
 			[self.lastTouchView touchesBeganWithEvent:event];
 			deliveringEvent = NO;
@@ -549,7 +515,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	// Since this is a continuation of a previously forwarded touch
 	// set, use the previously registered touch view.
 	// Block the internal event forwarding chain while doing this.
-	if(!deliveringEvent && self.lastTouchView) {
+	if (!deliveringEvent && self.lastTouchView) {
 		deliveringEvent = YES;
 		[self.lastTouchView touchesMovedWithEvent:event];
 		deliveringEvent = NO;
@@ -561,7 +527,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	// Since this is a continuation of a previously forwarded touch
 	// set, use the previously registered touch view and end it.
 	// Block the internal event forwarding chain while doing this.
-	if(!deliveringEvent && self.lastTouchView) {
+	if (!deliveringEvent && self.lastTouchView) {
 		deliveringEvent = YES;
 		[self.lastTouchView touchesEndedWithEvent:event];
 		deliveringEvent = NO;
@@ -576,7 +542,7 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	// Since this is a continuation of a previously forwarded touch
 	// set, use the previously registered touch view and end it.
 	// Block the internal event forwarding chain while doing this.
-	if(!deliveringEvent && self.lastTouchView) {
+	if (!deliveringEvent && self.lastTouchView) {
 		deliveringEvent = YES;
 		[self.lastTouchView touchesCancelledWithEvent:event];
 		deliveringEvent = NO;
@@ -588,83 +554,71 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 
 #pragma mark -
 
-- (void)beginGestureWithEvent:(NSEvent *)event
-{
+- (void)beginGestureWithEvent:(NSEvent *)event {
 	[[self viewForEvent:event] beginGestureWithEvent:event];
 }
 
-- (void)endGestureWithEvent:(NSEvent *)event
-{
+- (void)endGestureWithEvent:(NSEvent *)event {
 	[[self viewForEvent:event] endGestureWithEvent:event];
 }
 
-- (void)magnifyWithEvent:(NSEvent *)event
-{
-	if(!deliveringEvent) {
+- (void)magnifyWithEvent:(NSEvent *)event {
+	if (!deliveringEvent) {
 		deliveringEvent = YES;
 		[[self viewForEvent:event] magnifyWithEvent:event];	
 		deliveringEvent = NO;
 	}
 }
 
-- (void)rotateWithEvent:(NSEvent *)event
-{
-	if(!deliveringEvent) {
+- (void)rotateWithEvent:(NSEvent *)event {
+	if (!deliveringEvent) {
 		deliveringEvent = YES;
 		[[self viewForEvent:event] rotateWithEvent:event];
 		deliveringEvent = NO;
 	}
 }
 
-- (void)swipeWithEvent:(NSEvent *)event
-{
-	if(!deliveringEvent) {
+- (void)swipeWithEvent:(NSEvent *)event {
+	if (!deliveringEvent) {
 		deliveringEvent = YES;
 		[[self viewForEvent:event] swipeWithEvent:event];
 		deliveringEvent = NO;
 	}
 }
 
-- (void)keyDown:(NSEvent *)event
-{
+- (void)keyDown:(NSEvent *)event {
 	BOOL consumed = NO;
 	// TUIView uses -performKeyAction: in -keyDown: to do its key equivalents. If none of our TUIViews consumed the key down as a key action, we want to give our view controller a chance to handle the key down as a key equivalent.
-	if([[self nextResponder] isKindOfClass:[NSViewController class]]) {
+	if ([[self nextResponder] isKindOfClass:[NSViewController class]]) {
 		consumed = [[self nextResponder] performKeyEquivalent:event];
 	}
 	
-	if(!consumed) {
+	if (!consumed) {
 		[super keyDown:event];
 	}
 }
 
-- (BOOL)performKeyEquivalent:(NSEvent *)event
-{
+- (BOOL)performKeyEquivalent:(NSEvent *)event {
 	return [_rootView performKeyEquivalent:event];
 }
 
-- (void)setEverythingNeedsDisplay
-{
+- (void)setEverythingNeedsDisplay {
 	[_rootView setEverythingNeedsDisplay];
 }
 
-- (BOOL)isTrackingSubviewOfView:(TUIView *)v
-{
+- (BOOL)isTrackingSubviewOfView:(TUIView *)v {
 	return [self.trackingView isDescendantOfView:v];
 }
 
-- (BOOL)isHoveringSubviewOfView:(TUIView *)v
-{
+- (BOOL)isHoveringSubviewOfView:(TUIView *)v {
 	return [_hoverView isDescendantOfView:v];
 }
 
-- (BOOL)isHoveringView:(TUIView *)v
-{
+- (BOOL)isHoveringView:(TUIView *)v {
 	return _hoverView == v;
 }
 
-- (BOOL)acceptsFirstMouse:(NSEvent *)event
-{
+- (BOOL)acceptsFirstMouse:(NSEvent *)event {
 	return [[self viewForEvent:event] acceptsFirstMouse:event];
 }
 
@@ -677,37 +631,34 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
  - The NSApplication object’s delegate.
  */
 
-- (NSResponder *)firstResponderForSelector:(SEL)action
-{
-	if(!action)
+- (NSResponder *)firstResponderForSelector:(SEL)action {
+	if (!action)
 		return nil;
 	
 	NSResponder *f = [[self window] firstResponder];
 //	NSLog(@"starting search at %@", f);
 	do {
-		if([f respondsToSelector:action])
+		if ([f respondsToSelector:action])
 			return f;
 	} while((f = [f nextResponder]));
 	
 	return nil;
 }
 
-- (void)_patchMenu:(NSMenu *)menu
-{
+- (void)_patchMenu:(NSMenu *)menu {
 	for(NSMenuItem *item in [menu itemArray]) {
-		if(![item target]) {
+		if (![item target]) {
 			// would normally travel the responder chain starting too high up, patch it to target what it would target if it hit the true responder chain
 			[item setTarget:[self firstResponderForSelector:[item action]]];
 		}
 		
-		if([item submenu])
+		if ([item submenu])
 			[self _patchMenu:[item submenu]]; // recurse
 	}
 }
 
 // the problem is for context menus the responder chain search starts with the NSView... we want it to start deeper, so we can patch up targets of a copy of the menu here
-- (NSMenu *)menuWithPatchedItems:(NSMenu *)menu
-{
+- (NSMenu *)menuWithPatchedItems:(NSMenu *)menu {
 	NSData *d = [NSKeyedArchiver archivedDataWithRootObject:menu]; // this is bad - doesn't persist 'target'?
 	menu = [NSKeyedUnarchiver unarchiveObjectWithData:d];
 	
@@ -716,12 +667,11 @@ static NSComparisonResult compareNSViewOrdering (NSView *viewA, NSView *viewB, v
 	return menu;
 }
 
-- (NSMenu *)menuForEvent:(NSEvent *)event
-{
+- (NSMenu *)menuForEvent:(NSEvent *)event {
 	TUIView *v = [self viewForEvent:event];
 	do {
 		NSMenu *m = [v menuForEvent:event];
-		if(m)
+		if (m)
 			return m; // not patched
 		v = v.superview;
 	} while(v);

--- a/lib/UIKit/TUIScrollView.h
+++ b/lib/UIKit/TUIScrollView.h
@@ -119,31 +119,32 @@ typedef enum TUIScrollViewIndicator : NSUInteger {
 	BOOL x;
 	
 	struct {
-		unsigned int didChangeContentInset:1;
-		unsigned int bounceEnabled:1;
-		unsigned int alwaysBounceVertical:1;
-		unsigned int alwaysBounceHorizontal:1;
-		unsigned int mouseInside:1;
-		unsigned int mouseDownInScroller:1;
-		unsigned int ignoreNextScrollPhaseNormal_10_7:1;
-		unsigned int gestureBegan:1;
-		unsigned int animationMode:2;
-		unsigned int scrollDisabled:1;
-		unsigned int scrollIndicatorStyle:2;
-		unsigned int verticalScrollIndicatorVisibility:2;
-		unsigned int horizontalScrollIndicatorVisibility:2;
-		unsigned int verticalScrollIndicatorShowing:1;
-		unsigned int horizontalScrollIndicatorShowing:1;
-		unsigned int verticalScrollIndicatorExpanded:1;
-		unsigned int horizontalScrollIndicatorExpanded:1;
-		unsigned int delegateScrollViewDidScroll:1;
-		unsigned int delegateScrollViewWillBeginDragging:1;
-		unsigned int delegateScrollViewDidEndDragging:1;
-		unsigned int delegateScrollViewDidEndDecelerating:1;
-		unsigned int delegateScrollViewWillShowScrollIndicator:1;
-		unsigned int delegateScrollViewDidShowScrollIndicator:1;
-		unsigned int delegateScrollViewWillHideScrollIndicator:1;
-		unsigned int delegateScrollViewDidHideScrollIndicator:1;
+		unsigned didChangeContentInset:1;
+		unsigned bounceEnabled:1;
+		unsigned alwaysBounceVertical:1;
+		unsigned alwaysBounceHorizontal:1;
+		unsigned mouseInside:1;
+		unsigned mouseDownInScroller:1;
+		unsigned ignoreNextScrollPhaseNormal_10_7:1;
+		unsigned gestureBegan:1;
+		unsigned touchesBegan:1;
+		unsigned animationMode:2;
+		unsigned scrollDisabled:1;
+		unsigned scrollIndicatorStyle:2;
+		unsigned verticalScrollIndicatorVisibility:2;
+		unsigned horizontalScrollIndicatorVisibility:2;
+		unsigned verticalScrollIndicatorShowing:1;
+		unsigned horizontalScrollIndicatorShowing:1;
+		unsigned verticalScrollIndicatorExpanded:1;
+		unsigned horizontalScrollIndicatorExpanded:1;
+		unsigned delegateScrollViewDidScroll:1;
+		unsigned delegateScrollViewWillBeginDragging:1;
+		unsigned delegateScrollViewDidEndDragging:1;
+		unsigned delegateScrollViewDidEndDecelerating:1;
+		unsigned delegateScrollViewWillShowScrollIndicator:1;
+		unsigned delegateScrollViewDidShowScrollIndicator:1;
+		unsigned delegateScrollViewWillHideScrollIndicator:1;
+		unsigned delegateScrollViewDidHideScrollIndicator:1;
 	} _scrollViewFlags;
 }
 
@@ -172,6 +173,7 @@ typedef enum TUIScrollViewIndicator : NSUInteger {
 @property (nonatomic, readonly) CGPoint pullOffset;
 @property (nonatomic, readonly) CGPoint bounceOffset;
 
+@property (nonatomic, readonly, getter=isTracking) BOOL tracking;
 @property (nonatomic, readonly, getter=isDragging) BOOL dragging;
 @property (nonatomic, readonly, getter=isBouncing) BOOL bouncing;
 @property (nonatomic, readonly, getter=isDecelerating) BOOL decelerating;

--- a/lib/UIKit/TUIScrollView.m
+++ b/lib/UIKit/TUIScrollView.m
@@ -107,7 +107,7 @@ static BOOL isAtleastMountainLion = NO;
 	if ((self = [super initWithFrame:frame]))
 	{
 		_layer.masksToBounds = NO; // differs from UIKit
-		
+		[super setAcceptsTouchEvents:YES];
 		decelerationRate = 0.88;
 		
 		_scrollViewFlags.bounceEnabled = [self.class requiresElasticSrolling];
@@ -251,6 +251,15 @@ static BOOL isAtleastMountainLion = NO;
 - (void)setScrollEnabled:(BOOL)b
 {
 	_scrollViewFlags.scrollDisabled = !b;
+}
+
+// Force touch events through and disable resting touches.
+- (void)setAcceptsTouchEvents:(BOOL)acceptsTouchEvents {
+	[super setAcceptsTouchEvents:YES];
+}
+
+- (void)setWantsRestingTouches:(BOOL)wantsRestingTouches {
+	[super setWantsRestingTouches:NO];
 }
 
 - (TUIEdgeInsets)contentInset
@@ -1014,9 +1023,12 @@ static float clampBounce(float x) {
 	[self _updateScrollersAnimated:NO];
 }
 
-- (BOOL)isDragging
-{
+- (BOOL)isDragging {
 	return _scrollViewFlags.gestureBegan;
+}
+
+- (BOOL)isTracking {
+	return _scrollViewFlags.gestureBegan && _scrollViewFlags.touchesBegan;
 }
 
 - (BOOL)isDecelerating {
@@ -1284,8 +1296,10 @@ static float clampBounce(float x) {
 	}
 }
 
+#pragma mark - Scroller Visibility
+
 - (void)mouseDown:(NSEvent *)event onSubview:(TUIView *)subview {
-	if (subview == self.verticalScroller || subview == self.horizontalScroller){
+	if (subview == self.verticalScroller || subview == self.horizontalScroller) {
 		_scrollViewFlags.mouseDownInScroller = YES;
 		[self _updateScrollersAnimated:YES];
 	}
@@ -1294,7 +1308,7 @@ static float clampBounce(float x) {
 }
 
 - (void)mouseUp:(NSEvent *)event fromSubview:(TUIView *)subview {
-	if (subview == self.verticalScroller || subview == self.horizontalScroller){
+	if (subview == self.verticalScroller || subview == self.horizontalScroller) {
 		_scrollViewFlags.mouseDownInScroller = NO;
 		[self _updateScrollersAnimated:YES];
 	}
@@ -1305,7 +1319,7 @@ static float clampBounce(float x) {
 - (void)mouseEntered:(NSEvent *)event onSubview:(TUIView *)subview {
 	[super mouseEntered:event onSubview:subview];
 	
-	if (!_scrollViewFlags.mouseInside){
+	if (!_scrollViewFlags.mouseInside) {
 		_scrollViewFlags.mouseInside = YES;
 	}
 }
@@ -1314,13 +1328,33 @@ static float clampBounce(float x) {
 	[super mouseExited:event fromSubview:subview];
 	
 	CGPoint location = [self localPointForEvent:event];
-	CGRect visible = [self visibleRect];
-	CGPoint updatedLocation = CGPointMake(location.x, location.y + visible.origin.y);
+	CGPoint updatedLocation = CGPointMake(location.x, location.y + self.visibleRect.origin.y);
 	
-	if (_scrollViewFlags.mouseInside && ![self pointInside:updatedLocation withEvent:event]){
+	if (_scrollViewFlags.mouseInside && ![self pointInside:updatedLocation withEvent:event]) {
 		_scrollViewFlags.mouseInside = NO;
 	}
 }
+
+#pragma mark - Two-Finger Scroller Visibility
+
+- (void)touchesBeganWithEvent:(NSEvent *)event {
+	NSLog(@"pre begin %u", _scrollViewFlags.touchesBegan);
+	NSUInteger count = [self touchesMatchingPhase:NSTouchPhaseTouching forEvent:event].count;
+	_scrollViewFlags.touchesBegan = (count == 2);
+	NSLog(@"post begin %u", _scrollViewFlags.touchesBegan);
+}
+
+- (void)touchesEndedWithEvent:(NSEvent *)event {
+	NSLog(@"pre end %u", _scrollViewFlags.touchesBegan);
+	_scrollViewFlags.touchesBegan = NO;
+	NSLog(@"post end %u", _scrollViewFlags.touchesBegan);
+}
+
+- (void)touchesCancelledWithEvent:(NSEvent *)event {
+	[self touchesEndedWithEvent:event];
+}
+
+#pragma mark - Key Commands
 
 - (BOOL)performKeyAction:(NSEvent *)event {
 	switch ([[event charactersIgnoringModifiers] characterAtIndex:0]) {
@@ -1346,5 +1380,7 @@ static float clampBounce(float x) {
 	
 	return NO;
 }
+
+#pragma mark - 
 
 @end

--- a/lib/UIKit/TUIScrollView.m
+++ b/lib/UIKit/TUIScrollView.m
@@ -1023,12 +1023,12 @@ static float clampBounce(float x) {
 	[self _updateScrollersAnimated:NO];
 }
 
-- (BOOL)isDragging {
-	return _scrollViewFlags.gestureBegan;
+- (BOOL)isTracking {
+	return _scrollViewFlags.gestureBegan || _scrollViewFlags.touchesBegan;
 }
 
-- (BOOL)isTracking {
-	return _scrollViewFlags.gestureBegan && _scrollViewFlags.touchesBegan;
+- (BOOL)isDragging {
+	return _scrollViewFlags.gestureBegan;
 }
 
 - (BOOL)isDecelerating {
@@ -1319,9 +1319,8 @@ static float clampBounce(float x) {
 - (void)mouseEntered:(NSEvent *)event onSubview:(TUIView *)subview {
 	[super mouseEntered:event onSubview:subview];
 	
-	if (!_scrollViewFlags.mouseInside) {
+	if (!_scrollViewFlags.mouseInside)
 		_scrollViewFlags.mouseInside = YES;
-	}
 }
 
 - (void)mouseExited:(NSEvent *)event fromSubview:(TUIView *)subview {
@@ -1335,19 +1334,17 @@ static float clampBounce(float x) {
 	}
 }
 
-#pragma mark - Two-Finger Scroller Visibility
-
 - (void)touchesBeganWithEvent:(NSEvent *)event {
-	NSLog(@"pre begin %u", _scrollViewFlags.touchesBegan);
 	NSUInteger count = [self touchesMatchingPhase:NSTouchPhaseTouching forEvent:event].count;
 	_scrollViewFlags.touchesBegan = (count == 2);
-	NSLog(@"post begin %u", _scrollViewFlags.touchesBegan);
+	
+	[self _updateScrollersAnimated:YES];
 }
 
 - (void)touchesEndedWithEvent:(NSEvent *)event {
-	NSLog(@"pre end %u", _scrollViewFlags.touchesBegan);
 	_scrollViewFlags.touchesBegan = NO;
-	NSLog(@"post end %u", _scrollViewFlags.touchesBegan);
+	
+	[self _updateScrollersAnimated:YES];
 }
 
 - (void)touchesCancelledWithEvent:(NSEvent *)event {

--- a/lib/UIKit/TUIScroller.m
+++ b/lib/UIKit/TUIScroller.m
@@ -141,7 +141,7 @@ static NSTimeInterval const TUIScrollerDisplayDuration = 0.75f;
 }
 
 - (void)_hideKnob {
-	if (_scrollerFlags.hover || _scrollerFlags.active || self.scrollView.dragging || self.scrollView.decelerating) {
+	if (_scrollerFlags.hover || _scrollerFlags.active || self.scrollView.tracking || self.scrollView.decelerating) {
 		[self _refreshKnobTimer];
 		return;
 	}

--- a/lib/UIKit/TUIView+Event.h
+++ b/lib/UIKit/TUIView+Event.h
@@ -16,6 +16,18 @@
 
 @interface TUIView (Event)
 
+// Allows a TUIView to recieve touchesBegan/Moved/Ended/Cancelled events.
+// Defaults to NO.
+@property (nonatomic, assign) BOOL acceptsTouchEvents;
+
+// Allows a TUIView that can receive touch events to receive resting touches.
+// Defaults to NO.
+@property (nonatomic, assign) BOOL wantsRestingTouches;
+
+// Returns the set of touches for this TUIView provided by the NSEvent.
+// Note that you should not use -[NSEvent touchesMatchingPhase:inView:]
+- (NSSet *)touchesMatchingPhase:(NSTouchPhase)phase forEvent:(NSEvent *)event;
+
 - (BOOL)didDrag; // valid when called from mouseUp: will determine if a drag happened in this event sequence
 
 - (void)viewWillStartLiveResize; // call super to propogate to subviews

--- a/lib/UIKit/TUIView+Event.m
+++ b/lib/UIKit/TUIView+Event.m
@@ -22,6 +22,26 @@
 
 @implementation TUIView (Event)
 
+- (BOOL)acceptsTouchEvents {
+	return _viewFlags.acceptsTouchEvents;
+}
+
+- (void)setAcceptsTouchEvents:(BOOL)acceptsTouchEvents {
+	_viewFlags.acceptsTouchEvents = acceptsTouchEvents;
+}
+
+- (BOOL)wantsRestingTouches {
+	return _viewFlags.wantsRestingTouches;
+}
+
+- (void)setWantsRestingTouches:(BOOL)wantsRestingTouches {
+	_viewFlags.wantsRestingTouches = wantsRestingTouches;
+}
+
+- (NSSet *)touchesMatchingPhase:(NSTouchPhase)phase forEvent:(NSEvent *)event {
+	return [event touchesMatchingPhase:phase inView:self.nsView];
+}
+
 - (TUITextRenderer *)_textRendererForEvent:(NSEvent *)event
 {
 	CGPoint p = [self localPointForEvent:event];

--- a/lib/UIKit/TUIView.h
+++ b/lib/UIKit/TUIView.h
@@ -104,24 +104,24 @@ extern CGRect(^TUIViewCenteredLayout)(TUIView*);
 	} _context;
 	
 	struct {
-		unsigned userInteractionDisabled:1;
-		unsigned moveWindowByDragging:1;
-		unsigned resizeWindowByDragging:1;
-		unsigned didStartMovingByDragging:1;
-		unsigned didStartResizeByDragging:1;
-		unsigned disableSubpixelTextRendering:1;
-		unsigned pasteboardDraggingEnabled:1;
-		unsigned pasteboardDraggingIsDragging:1;
-		unsigned dragDistanceLock:1;
-		unsigned clearsContextBeforeDrawing:1;
-		unsigned drawInBackground:1;
-		unsigned needsDisplayWhenWindowsKeyednessChanges:1;
-		unsigned acceptsTouchEvents:1;
-		unsigned wantsRestingTouches:1;
+		unsigned int userInteractionDisabled:1;
+		unsigned int moveWindowByDragging:1;
+		unsigned int resizeWindowByDragging:1;
+		unsigned int didStartMovingByDragging:1;
+		unsigned int didStartResizeByDragging:1;
+		unsigned int disableSubpixelTextRendering:1;
+		unsigned int pasteboardDraggingEnabled:1;
+		unsigned int pasteboardDraggingIsDragging:1;
+		unsigned int dragDistanceLock:1;
+		unsigned int clearsContextBeforeDrawing:1;
+		unsigned int drawInBackground:1;
+		unsigned int needsDisplayWhenWindowsKeyednessChanges:1;
+		unsigned int acceptsTouchEvents:1;
+		unsigned int wantsRestingTouches:1;
 		
-		unsigned delegateMouseEntered:1;
-		unsigned delegateMouseExited:1;
-		unsigned delegateWillDisplayLayer:1;
+		unsigned int delegateMouseEntered:1;
+		unsigned int delegateMouseExited:1;
+		unsigned int delegateWillDisplayLayer:1;
 	} _viewFlags;
 
 	BOOL isAccessibilityElement;

--- a/lib/UIKit/TUIView.h
+++ b/lib/UIKit/TUIView.h
@@ -104,22 +104,24 @@ extern CGRect(^TUIViewCenteredLayout)(TUIView*);
 	} _context;
 	
 	struct {
-		unsigned int userInteractionDisabled:1;
-		unsigned int moveWindowByDragging:1;
-		unsigned int resizeWindowByDragging:1;
-		unsigned int didStartMovingByDragging:1;
-		unsigned int didStartResizeByDragging:1;
-		unsigned int disableSubpixelTextRendering:1;
-		unsigned int pasteboardDraggingEnabled:1;
-		unsigned int pasteboardDraggingIsDragging:1;
-		unsigned int dragDistanceLock:1;
-		unsigned int clearsContextBeforeDrawing:1;
-		unsigned int drawInBackground:1;
-		unsigned int needsDisplayWhenWindowsKeyednessChanges:1;
+		unsigned userInteractionDisabled:1;
+		unsigned moveWindowByDragging:1;
+		unsigned resizeWindowByDragging:1;
+		unsigned didStartMovingByDragging:1;
+		unsigned didStartResizeByDragging:1;
+		unsigned disableSubpixelTextRendering:1;
+		unsigned pasteboardDraggingEnabled:1;
+		unsigned pasteboardDraggingIsDragging:1;
+		unsigned dragDistanceLock:1;
+		unsigned clearsContextBeforeDrawing:1;
+		unsigned drawInBackground:1;
+		unsigned needsDisplayWhenWindowsKeyednessChanges:1;
+		unsigned acceptsTouchEvents:1;
+		unsigned wantsRestingTouches:1;
 		
-		unsigned int delegateMouseEntered:1;
-		unsigned int delegateMouseExited:1;
-		unsigned int delegateWillDisplayLayer:1;
+		unsigned delegateMouseEntered:1;
+		unsigned delegateMouseExited:1;
+		unsigned delegateWillDisplayLayer:1;
 	} _viewFlags;
 
 	BOOL isAccessibilityElement;


### PR DESCRIPTION
This allows `TUIView`s to support multitouch responder tracking using the prescribed `NSView` methods. There is one change, however: it is advised to use `-[TUIView touchesMatchingPhase:forEvent:]` instead of `-[NSEvent touchesMatchingPhase:inView:]` primarily because the former masks away the `TUINSView` need.

There are a few things I'd like to do to optimize this, though: better resting touch support, and more intelligent view caching for `TUINSView`, so it doesn't have to keep querying views for their capabilities.

This also provides two patches: a `TUIControl` patch to add a `-cancelTrackingWithEvent:` method that matches the touch method  of the near-same name, and one for `TUIScroller` to _much better_ match `NSScroller`'s visibility pattern.

@jwilling This is what the CC gave me. :P
