### PR TITLE
Fix TUIButton highlighted state.

### DIFF
--- a/lib/UIKit/TUIControl.m
+++ b/lib/UIKit/TUIControl.m
@@ -102,7 +102,7 @@
 	if (_controlFlags.hover)
 		actual |= TUIControlStateHover;
 	if (_controlFlags.tracking || _controlFlags.highlighted)
-		actual |= TUIControlStateHighlighted;
+		actual = (actual & ~TUIControlStateHover) | TUIControlStateHighlighted;
 	if (_controlFlags.selected)
 		actual |= TUIControlStateSelected;
 	


### PR DESCRIPTION
When a user clicks on a `TUIButton`, the highlighted image set by `setImage:forState:` won't display.

It's because of the `TUIControlStateHover` state introduced in commit 109c52582f8977e26024cd3e330046af1b1ae8b6. When a user's mouse is down, the TUIButton's state is now `TUIControlStateHover | TUIControlStateHighlighted`, instead of the original `TUIControlStateHighlighted`. So we will get no image for that combined state.

This is fixed by removing the `TUIControlStateHover` state when calculating the `state` value for `TUIControl` if the control is currently highlighted.
