### PR TITLE
Fix text renderer's view being nil'ed out in table view cell incorrectly

### DIFF
--- a/lib/UIKit/TUIView.m
+++ b/lib/UIKit/TUIView.m
@@ -526,8 +526,10 @@ static void TUISetCurrentContextScaleFactor(CGFloat s)
 	_currentTextRenderer = nil;
 	
 	for(TUITextRenderer *renderer in _textRenderers) {
-		renderer.view = nil;
-		[renderer setNextResponder:nil];
+		if (renderer.view == self) {
+			renderer.view = nil;
+			[renderer setNextResponder:nil];
+		}
 	}
 	
 	_textRenderers = renderers;


### PR DESCRIPTION
Text renderers could be add to a reusable table view cell before it's removed
from the original table view cell. In cases like this, the text renderers will
have view set nil when they are later removed from the original table view
cell, which causes all events to not be handled.
